### PR TITLE
added disconnect

### DIFF
--- a/pyvlx/interface.py
+++ b/pyvlx/interface.py
@@ -65,6 +65,11 @@ class Interface:
         self.token = json_response['token']
 
 
+    async def disconnect(self):
+        json_response = await self.api_call('auth', 'logout', {}, add_authorization_token=True)
+        self.token = None
+
+
     @staticmethod
     def create_api_url(host, verb):
         return 'http://{0}/api/v1/{1}'.format(host, verb)

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -16,6 +16,10 @@ class PyVLX:
         await self.interface.refresh_token()
 
 
+    async def disconnect(self):
+        await self.interface.disconnect()
+
+
     async def load_devices(self):
         await self.devices.load()
 

--- a/test.py
+++ b/test.py
@@ -15,6 +15,8 @@ async def main():
     # opening/ closing windows by running scenes, yay!
     await pyvlx.scenes[1].run()
 
+    await pyvlx.disconnect()
+
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())
 loop.close()


### PR DESCRIPTION
I just recognized that I’m not able to login to the KLF 200 webinterface at all after using the wrapper, because the KLF 200 allows only one logged in user at a time. I’m not a python developer at all, but added some lines to logout which only works if you call the disconnect method separately. I don’t know if this is best practice, but feels better than logging out automatically after each and every other call. So, for me it works. I call disconnect at the end of my script that uses the wrapper and am directly allowed to login to the webinterface to do some changes.