### PR TITLE
Enable management of dual shutters

### DIFF
--- a/pyvlx/devices.py
+++ b/pyvlx/devices.py
@@ -57,7 +57,7 @@ class Devices:
             category = item['category']
             if category == 'Window opener':
                 self.load_window_opener(item)
-            elif category == 'Roller shutter':
+            elif category in ['Roller shutter', 'Dual Shutter']:
                 self.load_roller_shutter(item)
             else:
                 print('WARNING: Could not parse product: {0}'.format(category))


### PR DESCRIPTION
Enable management of dual shutters. It is to be noted that dual shutters are not properly managed in Velux API v1, ie it is not possible to close the lower shutter without the upper one to be closed.