### PR TITLE
timeout of api calls configurable

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -7,7 +7,7 @@ async def main():
     """Load devices and scenes, run first scene."""
     pyvlx = PyVLX('pyvlx.yaml')
     # Alternative:
-    # pyvlx = PyVLX(host="192.168.2.127", password="velux123")
+    # pyvlx = PyVLX(host="192.168.2.127", password="velux123", timeout=60)
 
     await pyvlx.load_devices()
     print(pyvlx.devices[1])

--- a/pyvlx/interface.py
+++ b/pyvlx/interface.py
@@ -10,10 +10,11 @@ from .exception import PyVLXException, InvalidToken
 class Interface:
     """Interface to KLF 200."""
 
-    def __init__(self, config):
+    def __init__(self, config, timeout=10):
         """Initialize interface class."""
         self.config = config
         self.token = None
+        self.timeout = timeout
 
     # pylint: disable=too-many-arguments
     async def api_call(self, verb, action, params=None, add_authorization_token=True, retry=False):
@@ -50,7 +51,7 @@ class Interface:
     async def _do_http_request_impl(self, url, body, headers):
         print(url, body, headers)
         async with aiohttp.ClientSession() as session:
-            with async_timeout.timeout(10):
+            with async_timeout.timeout(self.timeout):
                 async with session.post(url, data=json.dumps(body), headers=headers) as response:
                     response = await response.text()
                     response = self.fix_response(response)

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -16,11 +16,11 @@ from .scenes import Scenes
 class PyVLX:
     """Class for PyVLX."""
 
-    def __init__(self, path=None, host=None, password=None):
+    def __init__(self, path=None, host=None, password=None, timeout=10):
         """Initialize PyVLX class."""
         self.logger = logging.getLogger('pyvlx.log')
         self.config = Config(self, path, host, password)
-        self.interface = Interface(self.config)
+        self.interface = Interface(self.config, timeout)
         self.devices = Devices(self)
         self.scenes = Scenes(self)
 


### PR DESCRIPTION
klf200 is responding after a request is fully handled again (e.g. running a scene is completed). Thus, a following request run into timeout, which needs to be made adjustable to users environment (e.g. a blind is running longer than a roller shutter)