### PR TITLE
Make nodes aware of their serial_number.

### DIFF
--- a/pyvlx/frames/frame_get_node_information.py
+++ b/pyvlx/frames/frame_get_node_information.py
@@ -68,7 +68,7 @@ class FrameGetNodeInformationConfirmation(FrameBase):
 
 
 class FrameGetNodeInformationNotification(FrameBase):
-    """Frame for notification of note information request."""
+    """Frame for notification of node information request."""
 
     PAYLOAD_LEN = 124
 
@@ -102,6 +102,10 @@ class FrameGetNodeInformationNotification(FrameBase):
     def serial_number(self):
         """Property for serial number in a human readable way."""
         return ":".join("{:02x}".format(c) for c in self._serial_number)
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        self._serial_number = serial_number
 
     def get_payload(self):
         """Return Payload."""

--- a/pyvlx/lightening_device.py
+++ b/pyvlx/lightening_device.py
@@ -8,7 +8,7 @@ from .parameter import Intensity
 class LighteningDevice(Node):
     """Meta class for turning on device with one main parameter for intensity."""
 
-    def __init__(self, pyvlx, node_id, name):
+    def __init__(self, pyvlx, node_id, name, serial_number):
         """Initialize turning on device.
 
         Parameters:
@@ -16,9 +16,10 @@ class LighteningDevice(Node):
             * node_id: internal id for addressing nodes.
                 Provided by KLF 200 device
             * name: node name
+            * serial_number: serial number of the node.
 
         """
-        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name)
+        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
         self.intensity = Intensity()
 
     async def set_intensity(self, intensity, wait_for_completion=True):
@@ -68,7 +69,7 @@ class LighteningDevice(Node):
 class Light(LighteningDevice):
     """Light object."""
 
-    def __init__(self, pyvlx, node_id, name):
+    def __init__(self, pyvlx, node_id, name, serial_number):
         """Initialize Light class.
 
         Parameters:
@@ -76,15 +77,18 @@ class Light(LighteningDevice):
             * node_id: internal id for addressing nodes.
                 Provided by KLF 200 device
             * name: node name
+            * serial_number: serial number of the node.
 
         """
-        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name)
+        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
 
     def __str__(self):
         """Return object as readable string."""
         return '<{} name="{}" ' \
-            'node_id="{}"/>' \
+            'node_id="{}" ' \
+            'serial_number="{}"/>' \
             .format(
                 type(self).__name__,
                 self.name,
-                self.node_id)
+                self.node_id,
+                self.serial_number)

--- a/pyvlx/node.py
+++ b/pyvlx/node.py
@@ -12,11 +12,12 @@ from .set_node_name import SetNodeName
 class Node:
     """Class for node abstraction."""
 
-    def __init__(self, pyvlx, node_id, name):
+    def __init__(self, pyvlx, node_id, name, serial_number):
         """Initialize Node object."""
         self.pyvlx = pyvlx
         self.node_id = node_id
         self.name = name
+        self.serial_number = serial_number
         self.device_updated_cbs = []
 
     def register_device_updated_cb(self, device_updated_cb):
@@ -44,11 +45,13 @@ class Node:
     def __str__(self):
         """Return object as readable string."""
         return '<{} name="{}" ' \
-            'node_id="{}"/>' \
+            'node_id="{}" ' \
+            'serial_number="{}"/>' \
             .format(
                 type(self).__name__,
                 self.name,
-                self.node_id)
+                self.node_id,
+                self.serial_number)
 
     def __eq__(self, other):
         """Equal operator."""

--- a/pyvlx/node_helper.py
+++ b/pyvlx/node_helper.py
@@ -11,32 +11,32 @@ def convert_frame_to_node(pyvlx, frame):
     """Convert FrameGet[All]Node[s]InformationNotification into Node object."""
     # pylint: disable=too-many-return-statements
     if frame.node_type == NodeTypeWithSubtype.WINDOW_OPENER:
-        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, rain_sensor=False)
+        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number, rain_sensor=False)
     if frame.node_type == NodeTypeWithSubtype.WINDOW_OPENER_WITH_RAIN_SENSOR:
-        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, rain_sensor=True)
+        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number, rain_sensor=True)
     if frame.node_type == NodeTypeWithSubtype.ROLLER_SHUTTER or \
             frame.node_type == NodeTypeWithSubtype.DUAL_ROLLER_SHUTTER:
-        return RollerShutter(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return RollerShutter(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.INTERIOR_VENETIAN_BLIND or \
             frame.node_type == NodeTypeWithSubtype.VERTICAL_INTERIOR_BLINDS or \
             frame.node_type == NodeTypeWithSubtype.EXTERIOR_VENETIAN_BLIND or \
             frame.node_type == NodeTypeWithSubtype.LOUVER_BLIND:
-        return Blind(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return Blind(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.VERTICAL_EXTERIOR_AWNING or \
             frame.node_type == NodeTypeWithSubtype.HORIZONTAL_AWNING:
-        return Awning(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return Awning(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.ON_OFF_SWITCH:
-        return OnOffSwitch(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return OnOffSwitch(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.GARAGE_DOOR_OPENER:
-        return GarageDoor(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return GarageDoor(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.GATE_OPENER:
-        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.GATE_OPENER_ANGULAR_POSITION:
-        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.BLADE_OPENER:
-        return Blade(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return Blade(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.LIGHT:
-        return Light(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name)
+        return Light(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
 
     PYVLXLOG.warning("%s not implemented", frame.node_type)
     return None

--- a/pyvlx/on_off_switch.py
+++ b/pyvlx/on_off_switch.py
@@ -8,9 +8,9 @@ from .parameter import SwitchParameter, SwitchParameterOff, SwitchParameterOn
 class OnOffSwitch(Node):
     """Class for controlling on-off switches."""
 
-    def __init__(self, pyvlx, node_id, name):
+    def __init__(self, pyvlx, node_id, name, serial_number):
         """Initialize opening device."""
-        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name)
+        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
         self.parameter = SwitchParameter()
 
     async def set_state(self, parameter):

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -100,11 +100,13 @@ class Window(OpeningDevice):
     def __str__(self):
         """Return object as readable string."""
         return '<{} name="{}" ' \
-            'node_id="{}" rain_sensor={}/>' \
+            'node_id="{}" rain_sensor={} ' \
+            'serial_number="{}"/>' \
             .format(
                 type(self).__name__,
                 self.name,
-                self.node_id, self.rain_sensor)
+                self.node_id, self.rain_sensor,
+                self.serial_number)
 
 
 class Blind(OpeningDevice):

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -8,7 +8,7 @@ from .parameter import CurrentPosition, Position
 class OpeningDevice(Node):
     """Meta class for opening device with one main parameter for position."""
 
-    def __init__(self, pyvlx, node_id, name):
+    def __init__(self, pyvlx, node_id, name, serial_number):
         """Initialize opening device.
 
         Parameters:
@@ -16,9 +16,10 @@ class OpeningDevice(Node):
             * node_id: internal id for addressing nodes.
                 Provided by KLF 200 device
             * name: node name
+            * serial_number: serial number of the node.
 
         """
-        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name)
+        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
         self.position = Position()
 
     async def set_position(self, position, wait_for_completion=True):
@@ -80,7 +81,7 @@ class OpeningDevice(Node):
 class Window(OpeningDevice):
     """Window object."""
 
-    def __init__(self, pyvlx, node_id, name, rain_sensor=False):
+    def __init__(self, pyvlx, node_id, name, serial_number, rain_sensor=False):
         """Initialize Window class.
 
         Parameters:
@@ -88,11 +89,12 @@ class Window(OpeningDevice):
             * node_id: internal id for addressing nodes.
                 Provided by KLF 200 device
             * name: node name
+            * serial_number: serial number of the node.
             * rain_sensor: set if device is equipped with a
                 rain sensor.
 
         """
-        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name)
+        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
         self.rain_sensor = rain_sensor
 
     def __str__(self):

--- a/test/lightening_device_test.py
+++ b/test/lightening_device_test.py
@@ -11,19 +11,19 @@ class TestLighteningDevice(unittest.TestCase):
     def test_light_str(self):
         """Test string representation of Light object."""
         pyvlx = PyVLX()
-        light = Light(pyvlx=pyvlx, node_id=23, name='Test Light')
-        self.assertEqual(str(light), '<Light name="Test Light" node_id="23"/>')
+        light = Light(pyvlx=pyvlx, node_id=23, name='Test Light', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(light), '<Light name="Test Light" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
 
     def test_eq(self):
         """Testing eq method with positive results."""
         pyvlx = PyVLX()
-        node1 = Light(pyvlx=pyvlx, node_id=23, name='xxx')
-        node2 = Light(pyvlx=pyvlx, node_id=23, name='xxx')
+        node1 = Light(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        node2 = Light(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
         self.assertEqual(node1, node2)
 
     def test_nq(self):
         """Testing eq method with negative results."""
         pyvlx = PyVLX()
-        node1 = Light(pyvlx=pyvlx, node_id=23, name='xxx')
-        node2 = Light(pyvlx=pyvlx, node_id=24, name='xxx')
+        node1 = Light(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        node2 = Light(pyvlx=pyvlx, node_id=24, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
         self.assertNotEqual(node1, node2)

--- a/test/node_helper_test.py
+++ b/test/node_helper_test.py
@@ -18,9 +18,10 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.WINDOW_OPENER
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, Window(pyvlx=pyvlx, name="Fnord23", node_id=23))
+        self.assertEqual(node, Window(pyvlx=pyvlx, name="Fnord23", node_id=23, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))
 
     def test_window_with_rain_sensor(self):
         """Test convert_frame_to_node with window with rain sensor."""
@@ -28,9 +29,10 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.WINDOW_OPENER_WITH_RAIN_SENSOR
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, Window(pyvlx=pyvlx, name="Fnord23", node_id=23, rain_sensor=True))
+        self.assertEqual(node, Window(pyvlx=pyvlx, name="Fnord23", node_id=23, rain_sensor=True, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))
 
     def test_blind(self):
         """Test convert_frame_to_node with blind."""
@@ -38,9 +40,10 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.INTERIOR_VENETIAN_BLIND
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, Blind(pyvlx=pyvlx, name="Fnord23", node_id=23))
+        self.assertEqual(node, Blind(pyvlx=pyvlx, name="Fnord23", node_id=23, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))
 
     def test_roller_shutter(self):
         """Test convert_frame_to_node roller shutter."""
@@ -48,9 +51,10 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.ROLLER_SHUTTER
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, RollerShutter(pyvlx=pyvlx, name="Fnord23", node_id=23))
+        self.assertEqual(node, RollerShutter(pyvlx=pyvlx, name="Fnord23", node_id=23, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))
 
     def test_garage_door(self):
         """Test convert_frame_to_node garage door."""
@@ -58,9 +62,10 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.GARAGE_DOOR_OPENER
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, GarageDoor(pyvlx=pyvlx, name="Fnord23", node_id=23))
+        self.assertEqual(node, GarageDoor(pyvlx=pyvlx, name="Fnord23", node_id=23, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))
 
     def test_blade(self):
         """Test convert_frame_to_node blade."""
@@ -68,9 +73,10 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.BLADE_OPENER
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, Blade(pyvlx=pyvlx, name="Fnord23", node_id=23))
+        self.assertEqual(node, Blade(pyvlx=pyvlx, name="Fnord23", node_id=23, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))
 
     def test_no_type(self):
         """Test convert_frame_to_node with no type (convert_frame_to_node should return None)."""
@@ -78,6 +84,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.NO_TYPE
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         self.assertEqual(convert_frame_to_node(pyvlx, frame), None)
 
@@ -87,6 +94,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.LIGHT
+        frame.serial_number = bytes.fromhex('aa bb aa bb aa bb aa 23')
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
-        self.assertEqual(node, Light(pyvlx=pyvlx, name="Fnord23", node_id=23))
+        self.assertEqual(node, Light(pyvlx=pyvlx, name="Fnord23", node_id=23, serial_number='aa:bb:aa:bb:aa:bb:aa:23'))

--- a/test/nodes_test.py
+++ b/test/nodes_test.py
@@ -13,11 +13,11 @@ class TestNodes(unittest.TestCase):
         """Test get_item."""
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
-        window = Window(pyvlx, 0, 'Window')
+        window = Window(pyvlx, 0, 'Window', 'aa:bb:aa:bb:aa:bb:aa:00')
         nodes.add(window)
-        blind = Blind(pyvlx, 1, 'Blind')
+        blind = Blind(pyvlx, 1, 'Blind', 'aa:bb:aa:bb:aa:bb:aa:01')
         nodes.add(blind)
-        roller_shutter = RollerShutter(pyvlx, 4, 'Roller Shutter')
+        roller_shutter = RollerShutter(pyvlx, 4, 'Roller Shutter', 'aa:bb:aa:bb:aa:bb:aa:04')
         nodes.add(roller_shutter)
         self.assertEqual(nodes['Window'], window)
         self.assertEqual(nodes['Blind'], blind)
@@ -30,7 +30,7 @@ class TestNodes(unittest.TestCase):
         """Test get_item with non existing object."""
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
-        window1 = Window(pyvlx, 0, 'Window_1')
+        window1 = Window(pyvlx, 0, 'Window_1', 'aa:bb:aa:bb:aa:bb:aa:00')
         nodes.add(window1)
         with self.assertRaises(KeyError):
             nodes['Window_2']  # pylint: disable=pointless-statement
@@ -41,9 +41,9 @@ class TestNodes(unittest.TestCase):
         """Test contains operator."""
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
-        window1 = Window(pyvlx, 23, 'Window_1')
+        window1 = Window(pyvlx, 23, 'Window_1', 'aa:bb:aa:bb:aa:bb:aa:23')
         nodes.add(window1)
-        window2 = Window(pyvlx, 42, 'Window_2')  # not added
+        window2 = Window(pyvlx, 42, 'Window_2', 'aa:bb:aa:bb:aa:bb:aa:42')  # not added
         self.assertTrue('Window_1' in nodes)
         self.assertTrue(23 in nodes)
         self.assertTrue(window1 in nodes)
@@ -55,11 +55,11 @@ class TestNodes(unittest.TestCase):
         """Test iterator."""
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
-        window1 = Window(pyvlx, 0, 'Window_1')
+        window1 = Window(pyvlx, 0, 'Window_1', 'aa:bb:aa:bb:aa:bb:aa:00')
         nodes.add(window1)
-        window2 = Window(pyvlx, 1, 'Window_2')
+        window2 = Window(pyvlx, 1, 'Window_2', 'aa:bb:aa:bb:aa:bb:aa:01')
         nodes.add(window2)
-        window3 = Window(pyvlx, 2, 'Window_3')
+        window3 = Window(pyvlx, 2, 'Window_3', 'aa:bb:aa:bb:aa:bb:aa:02')
         nodes.add(window3)
         self.assertEqual(
             tuple(nodes.__iter__()),
@@ -70,10 +70,10 @@ class TestNodes(unittest.TestCase):
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
         self.assertEqual(len(nodes), 0)
-        nodes.add(Window(pyvlx, 0, 'Window_1'))
-        nodes.add(Window(pyvlx, 1, 'Window_2'))
-        nodes.add(Window(pyvlx, 2, 'Window_3'))
-        nodes.add(Window(pyvlx, 3, 'Window_4'))
+        nodes.add(Window(pyvlx, 0, 'Window_1', 'aa:bb:aa:bb:aa:bb:aa:00'))
+        nodes.add(Window(pyvlx, 1, 'Window_2', 'aa:bb:aa:bb:aa:bb:aa:01'))
+        nodes.add(Window(pyvlx, 2, 'Window_3', 'aa:bb:aa:bb:aa:bb:aa:02'))
+        nodes.add(Window(pyvlx, 3, 'Window_4', 'aa:bb:aa:bb:aa:bb:aa:03'))
         self.assertEqual(len(nodes), 4)
 
     def test_add_same_object(self):
@@ -81,10 +81,10 @@ class TestNodes(unittest.TestCase):
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
         self.assertEqual(len(nodes), 0)
-        nodes.add(Window(pyvlx, 0, 'Window_1'))
-        nodes.add(Window(pyvlx, 1, 'Window_2'))
-        nodes.add(Window(pyvlx, 2, 'Window_3'))
-        nodes.add(Window(pyvlx, 1, 'Window_2_same_id'))
+        nodes.add(Window(pyvlx, 0, 'Window_1', 'aa:bb:aa:bb:aa:bb:aa:00'))
+        nodes.add(Window(pyvlx, 1, 'Window_2', 'aa:bb:aa:bb:aa:bb:aa:01'))
+        nodes.add(Window(pyvlx, 2, 'Window_3', 'aa:bb:aa:bb:aa:bb:aa:02'))
+        nodes.add(Window(pyvlx, 1, 'Window_2_same_id', 'aa:bb:aa:bb:aa:bb:aa:01'))
         self.assertEqual(len(nodes), 3)
         self.assertEqual(nodes[1].name, 'Window_2_same_id')
 
@@ -102,7 +102,7 @@ class TestNodes(unittest.TestCase):
         pyvlx = PyVLX()
         nodes = Nodes(pyvlx)
         self.assertEqual(len(nodes), 0)
-        nodes.add(Window(pyvlx, 0, 'Window_1'))
-        nodes.add(Window(pyvlx, 1, 'Window_2'))
+        nodes.add(Window(pyvlx, 0, 'Window_1', 'aa:bb:aa:bb:aa:bb:aa:00'))
+        nodes.add(Window(pyvlx, 1, 'Window_2', 'aa:bb:aa:bb:aa:bb:aa:01'))
         nodes.clear()
         self.assertEqual(len(nodes), 0)

--- a/test/opening_device_test.py
+++ b/test/opening_device_test.py
@@ -11,40 +11,40 @@ class TestOpeningDevice(unittest.TestCase):
     def test_window_str(self):
         """Test string representation of Window object."""
         pyvlx = PyVLX()
-        window = Window(pyvlx=pyvlx, node_id=23, name='Test Window', rain_sensor=True)
-        self.assertEqual(str(window), '<Window name="Test Window" node_id="23" rain_sensor=True/>')
+        window = Window(pyvlx=pyvlx, node_id=23, name='Test Window', rain_sensor=True, serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(window), '<Window name="Test Window" node_id="23" rain_sensor=True serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
 
     def test_blind_str(self):
         """Test string representation of Blind object."""
         pyvlx = PyVLX()
-        blind = Blind(pyvlx=pyvlx, node_id=23, name='Test Blind')
-        self.assertEqual(str(blind), '<Blind name="Test Blind" node_id="23"/>')
+        blind = Blind(pyvlx=pyvlx, node_id=23, name='Test Blind', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(blind), '<Blind name="Test Blind" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
 
     def test_roller_shutter_str(self):
         """Test string representation of RolllerShutter object."""
         pyvlx = PyVLX()
-        roller_shutter = RollerShutter(pyvlx=pyvlx, node_id=23, name='Test Roller Shutter')
-        self.assertEqual(str(roller_shutter), '<RollerShutter name="Test Roller Shutter" node_id="23"/>')
+        roller_shutter = RollerShutter(pyvlx=pyvlx, node_id=23, name='Test Roller Shutter', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(roller_shutter), '<RollerShutter name="Test Roller Shutter" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
 
     def test_blade_str(self):
         """Test string representation of Blade object."""
         pyvlx = PyVLX()
-        blade = Blade(pyvlx=pyvlx, node_id=23, name='Test Blade')
-        self.assertEqual(str(blade), '<Blade name="Test Blade" node_id="23"/>')
+        blade = Blade(pyvlx=pyvlx, node_id=23, name='Test Blade', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(blade), '<Blade name="Test Blade" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
 
     def test_eq(self):
         """Testing eq method with positive results."""
         pyvlx = PyVLX()
-        node1 = Blind(pyvlx=pyvlx, node_id=23, name='xxx')
-        node2 = Blind(pyvlx=pyvlx, node_id=23, name='xxx')
+        node1 = Blind(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        node2 = Blind(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
         self.assertEqual(node1, node2)
 
     def test_nq(self):
         """Testing eq method with negative results."""
         pyvlx = PyVLX()
-        node1 = Blind(pyvlx=pyvlx, node_id=23, name='xxx')
-        node2 = Blind(pyvlx=pyvlx, node_id=24, name='xxx')
-        node3 = RollerShutter(pyvlx=pyvlx, node_id=23, name='xxx')
+        node1 = Blind(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        node2 = Blind(pyvlx=pyvlx, node_id=24, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:24')
+        node3 = RollerShutter(pyvlx=pyvlx, node_id=23, name='xxx', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
         self.assertNotEqual(node1, node2)
         self.assertNotEqual(node2, node3)
         self.assertNotEqual(node3, node1)


### PR DESCRIPTION
Home Assistant wants entities to provide a unique id. Neither the host ip nor the node_id are unique. The PR adds the serial number during node initialization.
If the PR is accepted and pypi version containing the PR is available, I will update https://github.com/home-assistant/core/pull/34668

Regards, Thomas