### PR TITLE
Set initial position of OpeningDevice during node construction.

### DIFF
--- a/pyvlx/__init__.py
+++ b/pyvlx/__init__.py
@@ -4,7 +4,7 @@ from .exception import PyVLXException
 from .lightening_device import Light, LighteningDevice
 from .nodes import Nodes
 from .opening_device import (
-    Blade, Blind, GarageDoor, Gate, OpeningDevice, RollerShutter, Window)
+    Blade, Blind, GarageDoor, Gate, OpeningDevice, RollerShutter, Window, Awning)
 from .parameter import (
     CurrentIntensity, CurrentPosition, Intensity, Parameter, Position,
     SwitchParameter, SwitchParameterOff, SwitchParameterOn, UnknownIntensity,

--- a/pyvlx/node_helper.py
+++ b/pyvlx/node_helper.py
@@ -11,30 +11,39 @@ def convert_frame_to_node(pyvlx, frame):
     """Convert FrameGet[All]Node[s]InformationNotification into Node object."""
     # pylint: disable=too-many-return-statements
     if frame.node_type == NodeTypeWithSubtype.WINDOW_OPENER:
-        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number, rain_sensor=False)
+        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                      position_parameter=frame.current_position, rain_sensor=False)
     if frame.node_type == NodeTypeWithSubtype.WINDOW_OPENER_WITH_RAIN_SENSOR:
-        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number, rain_sensor=True)
+        return Window(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                      position_parameter=frame.current_position, rain_sensor=True)
     if frame.node_type == NodeTypeWithSubtype.ROLLER_SHUTTER or \
             frame.node_type == NodeTypeWithSubtype.DUAL_ROLLER_SHUTTER:
-        return RollerShutter(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return RollerShutter(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                             position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.INTERIOR_VENETIAN_BLIND or \
             frame.node_type == NodeTypeWithSubtype.VERTICAL_INTERIOR_BLINDS or \
             frame.node_type == NodeTypeWithSubtype.EXTERIOR_VENETIAN_BLIND or \
             frame.node_type == NodeTypeWithSubtype.LOUVER_BLIND:
-        return Blind(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return Blind(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                     position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.VERTICAL_EXTERIOR_AWNING or \
             frame.node_type == NodeTypeWithSubtype.HORIZONTAL_AWNING:
-        return Awning(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return Awning(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                      position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.ON_OFF_SWITCH:
         return OnOffSwitch(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
     if frame.node_type == NodeTypeWithSubtype.GARAGE_DOOR_OPENER:
-        return GarageDoor(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return GarageDoor(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                          position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.GATE_OPENER:
-        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                    position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.GATE_OPENER_ANGULAR_POSITION:
-        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return Gate(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                    position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.BLADE_OPENER:
-        return Blade(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
+        return Blade(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number,
+                     position_parameter=frame.current_position)
     if frame.node_type == NodeTypeWithSubtype.LIGHT:
         return Light(pyvlx=pyvlx, node_id=frame.node_id, name=frame.name, serial_number=frame.serial_number)
 

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -2,13 +2,13 @@
 from .command_send import CommandSend
 from .exception import PyVLXException
 from .node import Node
-from .parameter import CurrentPosition, Position
+from .parameter import CurrentPosition, Position, Parameter
 
 
 class OpeningDevice(Node):
     """Meta class for opening device with one main parameter for position."""
 
-    def __init__(self, pyvlx, node_id, name, serial_number):
+    def __init__(self, pyvlx, node_id, name, serial_number, position_parameter=Parameter()):
         """Initialize opening device.
 
         Parameters:
@@ -17,10 +17,11 @@ class OpeningDevice(Node):
                 Provided by KLF 200 device
             * name: node name
             * serial_number: serial number of the node.
+            * position_parameter: initial position of the opening device.
 
         """
         super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
-        self.position = Position()
+        self.position = Position(parameter=position_parameter)
 
     async def set_position(self, position, wait_for_completion=True):
         """Set window to desired position.
@@ -77,11 +78,24 @@ class OpeningDevice(Node):
             position=CurrentPosition(),
             wait_for_completion=wait_for_completion)
 
+    def __str__(self):
+        """Return object as readable string."""
+        return '<{} name="{}" ' \
+            'node_id="{}" ' \
+            'serial_number="{}" ' \
+            'position="{}"/>' \
+            .format(
+                type(self).__name__,
+                self.name,
+                self.node_id,
+                self.serial_number,
+                self.position)
+
 
 class Window(OpeningDevice):
     """Window object."""
 
-    def __init__(self, pyvlx, node_id, name, serial_number, rain_sensor=False):
+    def __init__(self, pyvlx, node_id, name, serial_number, position_parameter=Parameter(), rain_sensor=False):
         """Initialize Window class.
 
         Parameters:
@@ -90,23 +104,24 @@ class Window(OpeningDevice):
                 Provided by KLF 200 device
             * name: node name
             * serial_number: serial number of the node.
+            * position_parameter: initial position of the opening device.
             * rain_sensor: set if device is equipped with a
                 rain sensor.
 
         """
-        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number)
+        super().__init__(pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number, position_parameter=position_parameter)
         self.rain_sensor = rain_sensor
 
     def __str__(self):
         """Return object as readable string."""
         return '<{} name="{}" ' \
             'node_id="{}" rain_sensor={} ' \
-            'serial_number="{}"/>' \
+            'serial_number="{}" position="{}"/>' \
             .format(
                 type(self).__name__,
                 self.name,
                 self.node_id, self.rain_sensor,
-                self.serial_number)
+                self.serial_number, self.position)
 
 
 class Blind(OpeningDevice):

--- a/test/nodes_test.py
+++ b/test/nodes_test.py
@@ -2,6 +2,7 @@
 import unittest
 
 from pyvlx import Blind, Nodes, PyVLX, RollerShutter, Window
+from pyvlx.node import Node
 
 # pylint: disable=too-many-public-methods,invalid-name
 
@@ -106,3 +107,10 @@ class TestNodes(unittest.TestCase):
         nodes.add(Window(pyvlx, 1, 'Window_2', 'aa:bb:aa:bb:aa:bb:aa:01'))
         nodes.clear()
         self.assertEqual(len(nodes), 0)
+
+    def test_node_str(self):
+        """Test string representation of node."""
+        pyvlx = PyVLX()
+        node = Node(pyvlx=pyvlx, node_id=23, name='Test Abstract Node', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(node),
+                         '<Node name="Test Abstract Node" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')

--- a/test/opening_device_test.py
+++ b/test/opening_device_test.py
@@ -1,7 +1,7 @@
 """Unit test for roller shutter."""
 import unittest
 
-from pyvlx import Blade, Blind, PyVLX, RollerShutter, Window, Parameter
+from pyvlx import Blade, Blind, PyVLX, RollerShutter, Window, Awning, Parameter
 
 
 # pylint: disable=too-many-public-methods,invalid-name
@@ -34,6 +34,12 @@ class TestOpeningDevice(unittest.TestCase):
         pyvlx = PyVLX()
         blade = Blade(pyvlx=pyvlx, node_id=23, name='Test Blade', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
         self.assertEqual(str(blade), '<Blade name="Test Blade" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23" position="UNKNOWN"/>')
+
+    def test_awning_str(self):
+        """Test string representation of Awning object."""
+        pyvlx = PyVLX()
+        awning = Awning(pyvlx=pyvlx, node_id=23, name='Test Awning', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
+        self.assertEqual(str(awning), '<Awning name="Test Awning" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23" position="UNKNOWN"/>')
 
     def test_eq(self):
         """Testing eq method with positive results."""

--- a/test/opening_device_test.py
+++ b/test/opening_device_test.py
@@ -1,7 +1,7 @@
 """Unit test for roller shutter."""
 import unittest
 
-from pyvlx import Blade, Blind, PyVLX, RollerShutter, Window
+from pyvlx import Blade, Blind, PyVLX, RollerShutter, Window, Parameter
 
 
 # pylint: disable=too-many-public-methods,invalid-name
@@ -12,25 +12,28 @@ class TestOpeningDevice(unittest.TestCase):
         """Test string representation of Window object."""
         pyvlx = PyVLX()
         window = Window(pyvlx=pyvlx, node_id=23, name='Test Window', rain_sensor=True, serial_number='aa:bb:aa:bb:aa:bb:aa:23')
-        self.assertEqual(str(window), '<Window name="Test Window" node_id="23" rain_sensor=True serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
+        self.assertEqual(str(window),
+                         '<Window name="Test Window" node_id="23" rain_sensor=True serial_number="aa:bb:aa:bb:aa:bb:aa:23" position="UNKNOWN"/>')
 
     def test_blind_str(self):
         """Test string representation of Blind object."""
         pyvlx = PyVLX()
         blind = Blind(pyvlx=pyvlx, node_id=23, name='Test Blind', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
-        self.assertEqual(str(blind), '<Blind name="Test Blind" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
+        self.assertEqual(str(blind), '<Blind name="Test Blind" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23" position="UNKNOWN"/>')
 
     def test_roller_shutter_str(self):
         """Test string representation of RolllerShutter object."""
         pyvlx = PyVLX()
-        roller_shutter = RollerShutter(pyvlx=pyvlx, node_id=23, name='Test Roller Shutter', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
-        self.assertEqual(str(roller_shutter), '<RollerShutter name="Test Roller Shutter" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
+        roller_shutter = RollerShutter(pyvlx=pyvlx, node_id=23, name='Test Roller Shutter', serial_number='aa:bb:aa:bb:aa:bb:aa:23',
+                                       position_parameter=Parameter(Parameter.from_int(int(0.97*Parameter.MAX))))
+        self.assertEqual(str(roller_shutter),
+                         '<RollerShutter name="Test Roller Shutter" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23" position="97 %"/>')
 
     def test_blade_str(self):
         """Test string representation of Blade object."""
         pyvlx = PyVLX()
         blade = Blade(pyvlx=pyvlx, node_id=23, name='Test Blade', serial_number='aa:bb:aa:bb:aa:bb:aa:23')
-        self.assertEqual(str(blade), '<Blade name="Test Blade" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23"/>')
+        self.assertEqual(str(blade), '<Blade name="Test Blade" node_id="23" serial_number="aa:bb:aa:bb:aa:bb:aa:23" position="UNKNOWN"/>')
 
     def test_eq(self):
         """Testing eq method with positive results."""


### PR DESCRIPTION
This will allows to access the correct position states of opening devices directly after node creation.