### PR TITLE
Handle devices without serial numbers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ pypi:
 	@twine upload dist/*
 
 pylint:
-	@pylint -j 8 --rcfile=.pylintrc pyvlx test/*.py *.py examples/*.py
+	@pylint --rcfile=.pylintrc pyvlx test/*.py *.py examples/*.py
 
 pydocstyle:
 	 @pydocstyle pyvlx test/*.py test/*.py *.py examples/*.py

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -2,8 +2,7 @@
 import asyncio
 import logging
 
-from pyvlx import PyVLX
-from pyvlx.log import PYVLXLOG
+from pyvlx import PyVLX, PYVLXLOG
 
 
 async def main(loop):

--- a/pyvlx/__init__.py
+++ b/pyvlx/__init__.py
@@ -28,5 +28,6 @@ from .parameter import (
 
 # flake8: noqa
 from .pyvlx import PyVLX
+from .log import PYVLXLOG
 from .scene import Scene
 from .scenes import Scenes

--- a/pyvlx/frames/frame_get_all_nodes_information.py
+++ b/pyvlx/frames/frame_get_all_nodes_information.py
@@ -7,6 +7,7 @@ from pyvlx.alias_array import AliasArray
 from pyvlx.const import Command, NodeTypeWithSubtype, NodeVariation, Velocity
 from pyvlx.parameter import Parameter
 from pyvlx.string_helper import bytes_to_string, string_to_bytes
+from pyvlx.exception import PyVLXException
 
 from .frame import FrameBase
 
@@ -92,6 +93,18 @@ class FrameGetAllNodesInformationNotification(FrameBase):
         if self._serial_number == bytes(8):
             return None
         return ":".join("{:02x}".format(c) for c in self._serial_number)
+
+    @serial_number.setter
+    def serial_number(self, serial_number):
+        """Set serial number."""
+        if serial_number is None:
+            self._serial_number = bytes(8)
+            return
+        self._serial_number = b''
+        for elem in (serial_number.split(":")):
+            self._serial_number += bytes.fromhex(elem)
+        if len(self._serial_number) != 8:
+            raise PyVLXException("could_not_parse_serial_number")
 
     def get_payload(self):
         """Return Payload."""

--- a/pyvlx/frames/frame_get_all_nodes_information.py
+++ b/pyvlx/frames/frame_get_all_nodes_information.py
@@ -101,7 +101,7 @@ class FrameGetAllNodesInformationNotification(FrameBase):
             self._serial_number = bytes(8)
             return
         self._serial_number = b''
-        for elem in (serial_number.split(":")):
+        for elem in serial_number.split(":"):
             self._serial_number += bytes.fromhex(elem)
         if len(self._serial_number) != 8:
             raise PyVLXException("could_not_parse_serial_number")

--- a/pyvlx/frames/frame_get_all_nodes_information.py
+++ b/pyvlx/frames/frame_get_all_nodes_information.py
@@ -89,6 +89,8 @@ class FrameGetAllNodesInformationNotification(FrameBase):
     @property
     def serial_number(self):
         """Property for serial number in a human readable way."""
+        if self._serial_number == bytes(8):
+            return None
         return ":".join("{:02x}".format(c) for c in self._serial_number)
 
     def get_payload(self):

--- a/pyvlx/frames/frame_get_node_information.py
+++ b/pyvlx/frames/frame_get_node_information.py
@@ -7,6 +7,7 @@ from pyvlx.alias_array import AliasArray
 from pyvlx.const import Command, NodeTypeWithSubtype, NodeVariation, Velocity
 from pyvlx.parameter import Parameter
 from pyvlx.string_helper import bytes_to_string, string_to_bytes
+from pyvlx.exception import PyVLXException
 
 from .frame import FrameBase
 
@@ -109,7 +110,15 @@ class FrameGetNodeInformationNotification(FrameBase):
 
     @serial_number.setter
     def serial_number(self, serial_number):
-        self._serial_number = serial_number
+        """Set serial number."""
+        if serial_number is None:
+            self._serial_number = bytes(8)
+            return
+        self._serial_number = b''
+        for elem in (serial_number.split(":")):
+            self._serial_number += bytes.fromhex(elem)
+        if len(self._serial_number) != 8:
+            raise PyVLXException("could_not_parse_serial_number")
 
     def get_payload(self):
         """Return Payload."""

--- a/pyvlx/frames/frame_get_node_information.py
+++ b/pyvlx/frames/frame_get_node_information.py
@@ -103,6 +103,8 @@ class FrameGetNodeInformationNotification(FrameBase):
     @property
     def serial_number(self):
         """Property for serial number in a human readable way."""
+        if self._serial_number == bytes(8):
+            return None
         return ":".join("{:02x}".format(c) for c in self._serial_number)
 
     @serial_number.setter

--- a/pyvlx/frames/frame_get_node_information.py
+++ b/pyvlx/frames/frame_get_node_information.py
@@ -115,7 +115,7 @@ class FrameGetNodeInformationNotification(FrameBase):
             self._serial_number = bytes(8)
             return
         self._serial_number = b''
-        for elem in (serial_number.split(":")):
+        for elem in serial_number.split(":"):
             self._serial_number += bytes.fromhex(elem)
         if len(self._serial_number) != 8:
             raise PyVLXException("could_not_parse_serial_number")

--- a/pyvlx/node_updater.py
+++ b/pyvlx/node_updater.py
@@ -6,7 +6,7 @@ from .frames import (
 from .lightening_device import LighteningDevice
 from .opening_device import Blind, OpeningDevice
 from .parameter import Intensity, Parameter, Position
-from .pyvlx import PYVLXLOG
+from .log import PYVLXLOG
 
 
 class NodeUpdater:

--- a/test/frame_get_all_nodes_information_ntf_test.py
+++ b/test/frame_get_all_nodes_information_ntf_test.py
@@ -100,3 +100,16 @@ class TestFrameGetAllNodesInformationNotification(unittest.TestCase):
                 test_ts
             ),
         )
+
+    def test_serial_number(self):
+        """Test serial number property."""
+        frame = FrameGetAllNodesInformationNotification()
+        frame._serial_number = (  # pylint: disable=protected-access
+            b"\x01\x02\x03\x04\x05\x06\x06\x08"
+        )
+        self.assertEqual(frame.serial_number, "01:02:03:04:05:06:06:08")
+
+    def test_serial_number_none(self):
+        """Test serial number property with no value set."""
+        frame = FrameGetAllNodesInformationNotification()
+        self.assertEqual(frame.serial_number, None)

--- a/test/frame_get_all_nodes_information_ntf_test.py
+++ b/test/frame_get_all_nodes_information_ntf_test.py
@@ -7,6 +7,7 @@ from pyvlx.const import NodeTypeWithSubtype, NodeVariation, Velocity
 from pyvlx.frame_creation import frame_from_raw
 from pyvlx.frames import FrameGetAllNodesInformationNotification
 from pyvlx.parameter import Position
+from pyvlx.exception import PyVLXException
 
 
 class TestFrameGetAllNodesInformationNotification(unittest.TestCase):
@@ -38,9 +39,8 @@ class TestFrameGetAllNodesInformationNotification(unittest.TestCase):
         frame.node_variation = NodeVariation.TOPHUNG
         frame.power_mode = 1
         frame.build_number = 7
-        frame._serial_number = (  # pylint: disable=protected-access
-            b"\x01\x02\x03\x04\x05\x06\x06\x08"
-        )
+        frame.serial_number = "01:02:03:04:05:06:06:08"
+
         frame.state = 1
         frame.current_position = Position(position=12)
         frame.target = Position(position=123)
@@ -104,12 +104,22 @@ class TestFrameGetAllNodesInformationNotification(unittest.TestCase):
     def test_serial_number(self):
         """Test serial number property."""
         frame = FrameGetAllNodesInformationNotification()
-        frame._serial_number = (  # pylint: disable=protected-access
-            b"\x01\x02\x03\x04\x05\x06\x06\x08"
-        )
+        frame.serial_number = "01:02:03:04:05:06:06:08"
         self.assertEqual(frame.serial_number, "01:02:03:04:05:06:06:08")
 
     def test_serial_number_none(self):
         """Test serial number property with no value set."""
         frame = FrameGetAllNodesInformationNotification()
+        frame.serial_number = None
         self.assertEqual(frame.serial_number, None)
+
+    def test_serial_number_not_set(self):
+        """Test serial number property with not set."""
+        frame = FrameGetAllNodesInformationNotification()
+        self.assertEqual(frame.serial_number, None)
+
+    def test_wrong_serial_number(self):
+        """Test setting a wrong serial number."""
+        frame = FrameGetAllNodesInformationNotification()
+        with self.assertRaises(PyVLXException):
+            frame.serial_number = "01:02:03:04:05:06:06"

--- a/test/frame_get_all_nodes_information_ntf_test.py
+++ b/test/frame_get_all_nodes_information_ntf_test.py
@@ -38,7 +38,7 @@ class TestFrameGetAllNodesInformationNotification(unittest.TestCase):
         frame.node_variation = NodeVariation.TOPHUNG
         frame.power_mode = 1
         frame.build_number = 7
-        frame._serial_number = ( # pylint: disable=protected-access
+        frame._serial_number = (  # pylint: disable=protected-access
             b"\x01\x02\x03\x04\x05\x06\x06\x08"
         )
         frame.state = 1

--- a/test/frame_get_node_information_ntf_test.py
+++ b/test/frame_get_node_information_ntf_test.py
@@ -7,6 +7,7 @@ from pyvlx.const import NodeTypeWithSubtype, NodeVariation, Velocity
 from pyvlx.frame_creation import frame_from_raw
 from pyvlx.frames import FrameGetNodeInformationNotification
 from pyvlx.parameter import Position
+from pyvlx.exception import PyVLXException
 
 
 class TestFrameGetNodeInformationNotification(unittest.TestCase):
@@ -38,9 +39,8 @@ class TestFrameGetNodeInformationNotification(unittest.TestCase):
         frame.node_variation = NodeVariation.TOPHUNG
         frame.power_mode = 1
         frame.build_number = 7
-        frame._serial_number = (  # pylint: disable=protected-access
-            b"\x01\x02\x03\x04\x05\x06\x06\x08"
-        )
+        frame.serial_number = "01:02:03:04:05:06:06:08"
+
         frame.state = 1
         frame.current_position = Position(position=12)
         frame.target = Position(position=123)
@@ -104,12 +104,22 @@ class TestFrameGetNodeInformationNotification(unittest.TestCase):
     def test_serial_number(self):
         """Test serial number property."""
         frame = FrameGetNodeInformationNotification()
-        frame._serial_number = (  # pylint: disable=protected-access
-            b"\x01\x02\x03\x04\x05\x06\x06\x08"
-        )
+        frame.serial_number = "01:02:03:04:05:06:06:08"
         self.assertEqual(frame.serial_number, "01:02:03:04:05:06:06:08")
 
     def test_serial_number_none(self):
         """Test serial number property with no value set."""
         frame = FrameGetNodeInformationNotification()
+        frame.serial_number = None
         self.assertEqual(frame.serial_number, None)
+
+    def test_serial_number_not_set(self):
+        """Test serial number property with not set."""
+        frame = FrameGetNodeInformationNotification()
+        self.assertEqual(frame.serial_number, None)
+
+    def test_wrong_serial_number(self):
+        """Test setting a wrong serial number."""
+        frame = FrameGetNodeInformationNotification()
+        with self.assertRaises(PyVLXException):
+            frame.serial_number = "01:02:03:04:05:06:06"

--- a/test/frame_get_node_information_ntf_test.py
+++ b/test/frame_get_node_information_ntf_test.py
@@ -100,3 +100,16 @@ class TestFrameGetNodeInformationNotification(unittest.TestCase):
                 test_ts
             ),
         )
+
+    def test_serial_number(self):
+        """Test serial number property."""
+        frame = FrameGetNodeInformationNotification()
+        frame._serial_number = (  # pylint: disable=protected-access
+            b"\x01\x02\x03\x04\x05\x06\x06\x08"
+        )
+        self.assertEqual(frame.serial_number, "01:02:03:04:05:06:06:08")
+
+    def test_serial_number_none(self):
+        """Test serial number property with no value set."""
+        frame = FrameGetNodeInformationNotification()
+        self.assertEqual(frame.serial_number, None)

--- a/test/node_helper_test.py
+++ b/test/node_helper_test.py
@@ -18,7 +18,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.WINDOW_OPENER
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -37,7 +37,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.WINDOW_OPENER_WITH_RAIN_SENSOR
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -57,7 +57,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.EXTERIOR_VENETIAN_BLIND
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -76,7 +76,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.ROLLER_SHUTTER
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -95,7 +95,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.GARAGE_DOOR_OPENER
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -114,7 +114,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.GATE_OPENER
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -133,7 +133,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.GATE_OPENER_ANGULAR_POSITION
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -152,7 +152,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.BLADE_OPENER
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(
@@ -171,7 +171,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.NO_TYPE
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         self.assertEqual(convert_frame_to_node(pyvlx, frame), None)
 
@@ -181,7 +181,7 @@ class TestNodeHelper(unittest.TestCase):
         frame.node_id = 23
         frame.name = "Fnord23"
         frame.node_type = NodeTypeWithSubtype.LIGHT
-        frame.serial_number = bytes.fromhex("aa bb aa bb aa bb aa 23")
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         pyvlx = PyVLX()
         node = convert_frame_to_node(pyvlx, frame)
         self.assertEqual(


### PR DESCRIPTION
Background
------------

Looks like some devices don't report Serial numbers. This should be handled within HASS correctly.

@tschamm @pawlizio : Just an idea, what do you think?