### PR TITLE
reset heartbeat on .start()

### DIFF
--- a/pyvlx/heartbeat.py
+++ b/pyvlx/heartbeat.py
@@ -43,7 +43,10 @@ class Heartbeat:
             await self.loop_event.wait()
             if not self.stopped:
                 self.loop_event.clear()
-                await self.pulse()
+                try:
+                    await self.pulse()
+                except PyVLXException as e:
+                    pass
         self.cancel_loop_timeout()
         self.stopped_event.set()
 

--- a/pyvlx/heartbeat.py
+++ b/pyvlx/heartbeat.py
@@ -24,6 +24,7 @@ class Heartbeat:
 
     def start(self):
         """Create loop task."""
+        self.stopped = False
         self.run_task = self.pyvlx.loop.create_task(self.loop())
 
     async def stop(self):


### PR DESCRIPTION
Hi!

I have noticed that the heartbeats seem to stop after a KLF reboot (or any other reconnect).
After looking into the code it seems like the heartbeat is not recreated, so after the stop function was called once, the stopped parameter stays False and will never be set back to True. Therefore when start is called at the next reconnect (at least it seems like it is called) it will immediately stop again.

This PR has fixed the issue for me, but i did not dig deeper into the code and did not do rigorous testing.
As a side effect this seems to have fixed some issues with the HouseStatusmonitor (states were not being updated)