### PR TITLE
Convert unknown values to Position.UNKNOWN_VALUE rather than throwing an exception

### DIFF
--- a/pyvlx/parameter.py
+++ b/pyvlx/parameter.py
@@ -64,7 +64,7 @@ class Parameter:
                 and raw != Position.from_int(Position.UNKNOWN_VALUE)
                 and Position.to_int(raw) > Position.MAX
         ):
-            raise PyVLXException("parameter::raw_exceed_limit", raw=raw)
+            return Position.from_int(Position.UNKNOWN_VALUE)
         return raw
 
     def __eq__(self, other):

--- a/test/position_test.py
+++ b/test/position_test.py
@@ -44,6 +44,12 @@ class TestPosition(unittest.TestCase):
         self.assertEqual(Position(position_percent=50).position, 25600)
         self.assertEqual(Position(position=12345).position_percent, 24)
 
+    def test_fallback_to_unknown(self):
+        self.assertEqual(Parameter(raw=b"\xC8\x01"), Parameter(raw=Parameter.from_int(Parameter.UNKNOWN_VALUE)))
+        self.assertEqual(Parameter(raw=b"\xC9\x00"), Parameter(raw=Parameter.from_int(Parameter.UNKNOWN_VALUE)))
+        self.assertEqual(Parameter(raw=b"\xD8\x00"), Parameter(raw=Parameter.from_int(Parameter.UNKNOWN_VALUE)))
+        self.assertEqual(Parameter(raw=b"\xfe\x01"), Parameter(raw=Parameter.from_int(Parameter.UNKNOWN_VALUE)))
+
     def test_exception(self):
         """Test wrong initialization of Position."""
         with self.assertRaises(PyVLXException):
@@ -58,10 +64,6 @@ class TestPosition(unittest.TestCase):
             Position(position_percent=-1)
         with self.assertRaises(PyVLXException):
             Position(position_percent=101)
-        with self.assertRaises(PyVLXException):
-            Parameter(raw=b"\xC8\x01")
-        with self.assertRaises(PyVLXException):
-            Parameter(raw=b"\xC9\x00")
         with self.assertRaises(PyVLXException):
             Parameter(raw=b"\x00\x00\x00")
         with self.assertRaises(PyVLXException):


### PR DESCRIPTION
This PR fixes a problem I am having with Somfy Venetian Blinds.
They seem to send values that are not expected in pyvlx.

My solution is to not throw an exception during parsing but rather return UNKNOWN_VALUE. Throwing the exception caused the connection to be terminated. Which caused considerable lags when changing a value in HA because pyvlx had to first reconnect. At some point the gateway seems to get stuck and has to be unplugged, too.

Example exception from HA log:
```
pyvlx.exception.PyVLXException: <PyVLXException description="parameter::raw_exceed_limit" raw="b'\xfe\x01'"/>
pyvlx.exception.PyVLXException: <PyVLXException description="parameter::raw_exceed_limit" raw="b'\xd8\x00'"/>
```