### PR TITLE
Add Configuration options for open/close orientation

### DIFF
--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -172,8 +172,8 @@ class Blind(OpeningDevice):
         self.orientation = Position(position_percent=0)
         self.target_orientation = TargetPosition()
         self.target_position = TargetPosition()
-        self.open_orientation: float = 50
-        self.close_orientation: float = 100
+        self.open_orientation_target: float = 50
+        self.close_orientation_target: float = 100
 
     async def set_position_and_orientation(self, position, wait_for_completion=True, orientation=None):
         """Set window to desired position.
@@ -299,14 +299,14 @@ class Blind(OpeningDevice):
         Blind slats with ±90° orientation are open at 50%
         """
         await self.set_orientation(
-            orientation=Position(position_percent=self.open_orientation),
+            orientation=Position(position_percent=self.open_orientation_target),
             wait_for_completion=wait_for_completion,
         )
 
     async def close_orientation(self, wait_for_completion=True):
         """Close Blind slats."""
         await self.set_orientation(
-            orientation=Position(position_percent=self.close_orientation),
+            orientation=Position(position_percent=self.close_orientation_target),
             wait_for_completion=wait_for_completion,
         )
 

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -283,7 +283,7 @@ class Blind(OpeningDevice):
             pyvlx=self.pyvlx,
             wait_for_completion=wait_for_completion,
             node_id=self.node_id,
-            parameter=self.target_position,
+            parameter=IgnorePosition(),
             fp3=fp3,
         )
         await command_send.do_api_call()

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -283,7 +283,7 @@ class Blind(OpeningDevice):
             pyvlx=self.pyvlx,
             wait_for_completion=wait_for_completion,
             node_id=self.node_id,
-            parameter=IgnorePosition(),
+            parameter=self.target_position,
             fp3=fp3,
         )
         await command_send.do_api_call()

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -172,6 +172,8 @@ class Blind(OpeningDevice):
         self.orientation = Position(position_percent=0)
         self.target_orientation = TargetPosition()
         self.target_position = TargetPosition()
+        self.open_orientation: float = 50
+        self.close_orientation: float = 100
 
     async def set_position_and_orientation(self, position, wait_for_completion=True, orientation=None):
         """Set window to desired position.
@@ -297,14 +299,14 @@ class Blind(OpeningDevice):
         Blind slats with ±90° orientation are open at 50%
         """
         await self.set_orientation(
-            orientation=Position(position_percent=50),
+            orientation=Position(position_percent=self.open_orientation),
             wait_for_completion=wait_for_completion,
         )
 
     async def close_orientation(self, wait_for_completion=True):
         """Close Blind slats."""
         await self.set_orientation(
-            orientation=Position(position_percent=100),
+            orientation=Position(position_percent=self.close_orientation),
             wait_for_completion=wait_for_completion,
         )
 


### PR DESCRIPTION
This solves #123

I've prepared and tested a configuration posibility via HA. For open_orientation and close_orientation I've created NumberEntities which can be adjusted by a slider in HA between a range of 0 and 100. So you can define your desired open and close orientation which will be used if you press the arrow buttons. You can try this also using my custom compent, but you have to use the branch "add_orientation_config": https://github.com/pawlizio/my_velux/tree/add_orientation_config
 
It looks as follows: 
![image](https://user-images.githubusercontent.com/15065886/143612856-654cb3b2-f71e-4755-a46f-05cc28ad4ed5.png)