### PR TITLE
Enable support for target position for RollerShutter.

### DIFF
--- a/pyvlx/node_helper.py
+++ b/pyvlx/node_helper.py
@@ -41,6 +41,7 @@ def convert_frame_to_node(pyvlx, frame):
             name=frame.name,
             serial_number=frame.serial_number,
             position_parameter=frame.current_position,
+            target_position_parameter=frame.target,
         )
 
     if frame.node_type in [

--- a/pyvlx/node_updater.py
+++ b/pyvlx/node_updater.py
@@ -71,6 +71,9 @@ class NodeUpdater:
             elif isinstance(node, OpeningDevice):
                 if position.position <= Parameter.MAX:
                     node.position = position
+                target_position = Position(frame.target)
+                if target_position.position <= Parameter.MAX:
+                    node.target_position = target_position
                 await node.after_update()
             elif isinstance(node, LighteningDevice):
                 intensity = Intensity(frame.current_position)

--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -11,7 +11,7 @@ class OpeningDevice(Node):
     """Meta class for opening device with one main parameter for position."""
 
     def __init__(
-            self, pyvlx, node_id, name, serial_number, position_parameter=Parameter()
+            self, pyvlx, node_id, name, serial_number, position_parameter=Parameter(), target_position_parameter=Parameter()
     ):
         """Initialize opening device.
 
@@ -28,6 +28,7 @@ class OpeningDevice(Node):
             pyvlx=pyvlx, node_id=node_id, name=name, serial_number=serial_number
         )
         self.position = Position(parameter=position_parameter)
+        self.target_position = Position(parameter=target_position_parameter)
 
     async def set_position(self, position, wait_for_completion=True):
         """Set window to desired position.


### PR DESCRIPTION
This PR adds `target_position` to `RollerShutter` which will enable us to detect, if the device is closing or opening (or not) in HomeAssistant.