### PR TITLE
Uses a Semaphore to limit API calls to one at a time to avoid KLF issues

### DIFF
--- a/pyvlx/api/api_event.py
+++ b/pyvlx/api/api_event.py
@@ -22,8 +22,7 @@ class ApiEvent:
         self.timeout_handle: Optional[asyncio.TimerHandle] = None
 
     async def do_api_call(self) -> None:
-        """Start. Sending and waiting for answer."""
-        
+        """Start. Sending and waiting for answer."""        
         # We check for connection before entering the semaphore section
         # because otherwise we might try to connect, which calls this, and we get stuck on
         # the semaphore.

--- a/pyvlx/api/api_event.py
+++ b/pyvlx/api/api_event.py
@@ -28,7 +28,7 @@ class ApiEvent:
         # the semaphore.
         await self.pyvlx.check_connected()
 
-        async with self.pyvlx.sem:
+        async with self.pyvlx.api_call_semaphore:
             self.pyvlx.connection.register_frame_received_cb(self.response_rec_callback)
             await self.send_frame()
             await self.start_timeout()

--- a/pyvlx/api/api_event.py
+++ b/pyvlx/api/api_event.py
@@ -22,12 +22,12 @@ class ApiEvent:
         self.timeout_handle: Optional[asyncio.TimerHandle] = None
 
     async def do_api_call(self) -> None:
-        """Start. Sending and waiting for answer."""        
+        """Start. Sending and waiting for answer."""
         # We check for connection before entering the semaphore section
         # because otherwise we might try to connect, which calls this, and we get stuck on
         # the semaphore.
         await self.pyvlx.check_connected()
-        
+
         async with self.pyvlx.sem:
             self.pyvlx.connection.register_frame_received_cb(self.response_rec_callback)
             await self.send_frame()

--- a/pyvlx/api/get_all_nodes_information.py
+++ b/pyvlx/api/get_all_nodes_information.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class GetAllNodesInformation(ApiEvent):
-    """Class for retrieving node informationfrom API."""
+    """Class for retrieving node information from API."""
 
     def __init__(self, pyvlx: "PyVLX"):
         """Initialize SceneList class."""

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -69,6 +69,7 @@ class PyVLX:
         await self.klf200.reboot()
 
     async def check_connected(self) -> None:
+        """Check we're connected, and if not, connect."""
         if not self.connection.connected:
             await self.connect()
 

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -41,6 +41,7 @@ class PyVLX:
         self.version = None
         self.protocol_version = None
         self.klf200 = Klf200Gateway(pyvlx=self)
+        self.sem = asyncio.Semaphore(1) # Limit parallel commands
 
     async def connect(self) -> None:
         """Connect to KLF 200."""
@@ -67,10 +68,13 @@ class PyVLX:
         PYVLXLOG.warning("KLF 200 reboot initiated")
         await self.klf200.reboot()
 
-    async def send_frame(self, frame: FrameBase) -> None:
-        """Send frame to API via connection."""
+    async def check_connected(self) -> None:
         if not self.connection.connected:
             await self.connect()
+
+    async def send_frame(self, frame: FrameBase) -> None:
+        """Send frame to API via connection."""
+        await self.check_connected()
         self.connection.write(frame)
 
     async def disconnect(self) -> None:

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -41,7 +41,7 @@ class PyVLX:
         self.version = None
         self.protocol_version = None
         self.klf200 = Klf200Gateway(pyvlx=self)
-        self.sem = asyncio.Semaphore(1) # Limit parallel commands
+        self.sem = asyncio.Semaphore(1)  # Limit parallel commands
 
     async def connect(self) -> None:
         """Connect to KLF 200."""

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -41,7 +41,7 @@ class PyVLX:
         self.version = None
         self.protocol_version = None
         self.klf200 = Klf200Gateway(pyvlx=self)
-        self.sem = asyncio.Semaphore(1)  # Limit parallel commands
+        self.api_call_semaphore = asyncio.Semaphore(1)  # Limit parallel commands
 
     async def connect(self) -> None:
         """Connect to KLF 200."""


### PR DESCRIPTION
Fixes #331. I've tested this a few times with a set of 6 blinds, and if I do `node.close()` for all of them in parallel without this, I get roughly half closing (sometimes 2, sometimes 4-5). With this change they appear pretty stable all 6 happening. They don't quite run all at the same time, there's a bit of a gap between them (1s maybe?), but that's a lot better than them not closing.