### PR TITLE
Fix blind orientation on first call

### DIFF
--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -272,8 +272,8 @@ class Blind(OpeningDevice):
             position_parameter=position_parameter,
         )
         self.orientation: Position = Position(position_percent=0)
-        self.target_orientation: Position = Position()
-        self.target_position: Position = Position()
+        self.target_orientation: Position = TargetPosition()
+        self.target_position: Position = TargetPosition()
         self.open_orientation_target: int = 50
         self.close_orientation_target: int = 100
 


### PR DESCRIPTION
We should initiate with TargetPosition, otherwise Blind orientation can not be changed until position has been changed on HA start.