### PR TITLE
Reboot KLF200 on disconnect

### DIFF
--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -50,7 +50,7 @@ class PyVLX:
         self.protocol_version = None
         self.klf200 = Klf200Gateway(pyvlx=self)
         self.api_call_semaphore = asyncio.Semaphore(1)  # Limit parallel commands
-        PYVLXLOG.debug("Loadig pyvlx v0.1.76")
+        PYVLXLOG.debug("Loadig pyvlx v0.2.21")
 
     async def connect(self) -> None:
         """Connect to KLF 200."""
@@ -95,6 +95,8 @@ class PyVLX:
         except (OSError, PyVLXException):
             pass
         await self.heartbeat.stop()
+        # Reboot KLF200 when disconnecting in order to avoid unresponsive KLF200.
+        await self.klf200.reboot()
         self.connection.disconnect()
 
     async def load_nodes(self, node_id: Optional[int] = None) -> None:

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -95,7 +95,7 @@ class PyVLX:
         except (OSError, PyVLXException):
             pass
         await self.heartbeat.stop()
-        # Reboot KLF200 when disconnecting in order to avoid unresponsive KLF200.
+        # Reboot KLF200 when disconnecting to avoid unresponsive KLF200.
         await self.klf200.reboot()
         self.connection.disconnect()
 

--- a/pyvlx/pyvlx.py
+++ b/pyvlx/pyvlx.py
@@ -50,7 +50,7 @@ class PyVLX:
         self.protocol_version = None
         self.klf200 = Klf200Gateway(pyvlx=self)
         self.api_call_semaphore = asyncio.Semaphore(1)  # Limit parallel commands
-        PYVLXLOG.debug("Loadig pyvlx v0.2.21")
+        PYVLXLOG.debug("Loadig pyvlx v0.1.76")
 
     async def connect(self) -> None:
         """Connect to KLF 200."""

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIRES = ["PyYAML"]
 
 PKG_ROOT = os.path.dirname(__file__)
 
-VERSION = "0.2.21"
+VERSION = "0.1.76"
 
 
 def get_long_description() -> str:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIRES = ["PyYAML"]
 
 PKG_ROOT = os.path.dirname(__file__)
 
-VERSION = "0.1.76"
+VERSION = "0.2.21"
 
 
 def get_long_description() -> str:


### PR DESCRIPTION
I think we should include the reboot function directly into KLF200 disconnect command. I know the KLF200 open it's WIFI Access Point on restart, however you need to have the creditentials to connect to this AP, so I think this solution can be justified as workaround.

This PR is a workaround to avoid #53, #68 and #30