### PR TITLE
Update setup.py, exclude 'test'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=['test*']),
     package_data={
         "pyvlx": ["py.typed"],
     },


### PR DESCRIPTION
Otherwise:

```
* Messages for package dev-python/pyvlx-0.2.21:

 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/test
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/pyvlx-0.2.21::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
```

I hope you don't mind I included your component for [Home Assistant Gentoo Overlay](https://github.com/onkelbeh/HomeAssistantRepository). I do not use this component myself. But, during compilation test, the installation test script threw an error, because `setup.py` tries to install a package called `tests` at top level.

My change only adds a generic exclusion to find_packages().