### PR TITLE
Correct the Heartbeat pulse process for garage door

### DIFF
--- a/pyvlx/api/frames/frame_status_request.py
+++ b/pyvlx/api/frames/frame_status_request.py
@@ -21,7 +21,7 @@ class FrameStatusRequestRequest(FrameBase):
         self.session_id = session_id
         self.node_ids = node_ids if node_ids is not None else []
         self.status_type = StatusType.REQUEST_CURRENT_POSITION
-        self.fpi1 = 254     # Request FP1 to FP7
+        self.fpi1 = 0
         self.fpi2 = 0
 
     def get_payload(self) -> bytes:

--- a/test/frame_status_request_test.py
+++ b/test/frame_status_request_test.py
@@ -30,7 +30,7 @@ class TestFrameStatusRequestRequest(unittest.TestCase):
         """Test string representation of FrameStatusRequestRequest."""
         frame = FrameStatusRequestRequest(node_ids=[1, 2], session_id=0xAB)
         self.assertEqual(str(frame), "<FrameStatusRequestRequest session_id=\"171\" node_ids=\"[1, 2]\" "
-                                     "status_type=\"StatusType.REQUEST_CURRENT_POSITION\" fpi1=\"254\" fpi2=\"0\"/>")
+                                     "status_type=\"StatusType.REQUEST_CURRENT_POSITION\" fpi1=\"0\" fpi2=\"0\"/>")
 
 
 class TestFrameStatusRequestConfirmation(unittest.TestCase):


### PR DESCRIPTION
In class FrameStatusRequestRequest, FPI1=254 creates an error for garage door ( opening device )
With FPI1=0, the error is gone and other equipements are reporting correctly.