### PR TITLE
Add run_status and status_reply to FrameCommandRunStatusNotification.

### DIFF
--- a/pyvlx/api/frames/__init__.py
+++ b/pyvlx/api/frames/__init__.py
@@ -10,7 +10,8 @@ from .frame_activation_log_updated import FrameActivationLogUpdatedNotification
 from .frame_command_send import (
     CommandSendConfirmationStatus, FrameCommandRemainingTimeNotification,
     FrameCommandRunStatusNotification, FrameCommandSendConfirmation,
-    FrameCommandSendRequest, FrameSessionFinishedNotification)
+    FrameCommandSendRequest, FrameSessionFinishedNotification,
+    CommandNotificationRunStatus, CommandNotificationStatusReply)
 from .frame_discover_nodes import (
     FrameDiscoverNodesConfirmation, FrameDiscoverNodesNotification,
     FrameDiscoverNodesRequest)

--- a/pyvlx/api/frames/frame_command_send.py
+++ b/pyvlx/api/frames/frame_command_send.py
@@ -152,6 +152,60 @@ class FrameCommandSendConfirmation(FrameBase):
             type(self).__name__, self.session_id, self.status
         )
 
+class CommandNotificationRunStatus(Enum):
+    """Enum class for run_status parameter in FrameCommandRunStatusNotification."""
+
+    EXECUTION_COMPLETED = 0
+    EXECUTION_FAILED = 1
+    EXECUTION_ACTIVE = 2
+
+class CommandNotificationStatusReply(Enum):
+    """Enum class for status_reply parameter in FrameCommandRunStatusNotification."""
+
+    UNKNOWN_STATUS_REPLY = 0x00
+    COMMAND_COMPLETED_OK = 0x01
+    NO_CONTACT = 0x02
+    MANUALLY_OPERATED = 0x03
+    BLOCKED = 0x04
+    WRONG_SYSTEMKEY = 0x05
+    PRIORITY_LEVEL_LOCKED = 0x06
+    REACHED_WRONG_POSITION = 0x07
+    ERROR_DURING_EXECUTION = 0x08
+    NO_EXECUTION = 0x09
+    CALIBRATING = 0x0A
+    POWER_CONSUMPTION_TOO_HIGH = 0x0B
+    POWER_CONSUMPTION_TOO_LOW = 0x0C
+    LOCK_POSITION_OPEN = 0x0D
+    MOTION_TIME_TOO_LONG__COMMUNICATION_ENDED = 0x0E
+    THERMAL_PROTECTION = 0x0F
+    PRODUCT_NOT_OPERATIONAL = 0x10
+    FILTER_MAINTENANCE_NEEDED = 0x11
+    BATTERY_LEVEL = 0x12
+    TARGET_MODIFIED = 0x13
+    MODE_NOT_IMPLEMENTED = 0x14
+    COMMAND_INCOMPATIBLE_TO_MOVEMENT = 0x15
+    USER_ACTION = 0x16
+    DEAD_BOLT_ERROR = 0x17
+    AUTOMATIC_CYCLE_ENGAGED = 0x18
+    WRONG_LOAD_CONNECTED = 0x19
+    COLOUR_NOT_REACHABLE = 0x1A
+    TARGET_NOT_REACHABLE = 0x1B
+    BAD_INDEX_RECEIVED = 0x1C
+    COMMAND_OVERRULED = 0x1D
+    NODE_WAITING_FOR_POWER = 0x1E
+    INFORMATION_CODE = 0xDF
+    PARAMETER_LIMITED = 0xE0
+    LIMITATION_BY_LOCAL_USER = 0xE1
+    LIMITATION_BY_USER = 0xE2
+    LIMITATION_BY_RAIN = 0xE3
+    LIMITATION_BY_TIMER = 0xE4
+    LIMITATION_BY_UPS = 0xE6
+    LIMITATION_BY_UNKNOWN_DEVICE = 0xE7
+    LIMITATION_BY_SAAC = 0xEA
+    LIMITATION_BY_WIND = 0xEB
+    LIMITATION_BY_MYSELF = 0xEC
+    LIMITATION_BY_AUTOMATIC_CYCLE = 0xED
+    LIMITATION_BY_EMERGENCY = 0xEE
 
 class FrameCommandRunStatusNotification(FrameBase):
     """Frame for run status notification in scope of command send frame."""
@@ -165,6 +219,8 @@ class FrameCommandRunStatusNotification(FrameBase):
             index_id: Optional[int] = None,
             node_parameter: Optional[int] = None,
             parameter_value: Optional[int] = None,
+            run_status: Optional[CommandNotificationRunStatus] = None,
+            status_reply: CommandNotificationStatusReply = None,
     ):
         """Init Frame."""
         super().__init__(Command.GW_COMMAND_RUN_STATUS_NTF)
@@ -173,6 +229,8 @@ class FrameCommandRunStatusNotification(FrameBase):
         self.index_id = index_id
         self.node_parameter = node_parameter
         self.parameter_value = parameter_value
+        self.run_status = run_status
+        self.status_reply = status_reply
 
     def get_payload(self) -> bytes:
         """Return Payload."""
@@ -186,9 +244,13 @@ class FrameCommandRunStatusNotification(FrameBase):
         ret += bytes([self.node_parameter])
         assert self.parameter_value is not None
         ret += bytes([self.parameter_value >> 8 & 255, self.parameter_value & 255])
+        assert self.run_status is not None
+        ret += bytes([self.run_status.value])
+        assert self.status_reply is not None
+        ret += bytes([self.status_reply.value])
 
-        # XXX: Missing implementation of run_status, status_reply and information_code
-        ret += bytes(6)
+        # XXX: Missing implementation of information_code
+        ret += bytes(4)
         return ret
 
     def from_payload(self, payload: bytes) -> None:
@@ -198,15 +260,17 @@ class FrameCommandRunStatusNotification(FrameBase):
         self.index_id = payload[3]
         self.node_parameter = payload[4]
         self.parameter_value = payload[5] * 256 + payload[6]
+        self.run_status = CommandNotificationRunStatus(payload[7])
+        self.status_reply = CommandNotificationStatusReply(payload[8])
 
     def __str__(self) -> str:
         """Return human readable string."""
         return (
             '<{} session_id="{}" status_id="{}" '
-            'index_id="{}" node_parameter="{}" parameter_value="{}"/>'.format(
+            'index_id="{}" node_parameter="{}" parameter_value="{}" run_status="{}" status_reply="{}"/>'.format(
                 type(self).__name__, self.session_id,
                 self.status_id, self.index_id,
-                self.node_parameter, self.parameter_value
+                self.node_parameter, self.parameter_value, self.run_status, self.status_reply
             )
         )
 

--- a/test/frame_command_run_status_notification_test.py
+++ b/test/frame_command_run_status_notification_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 from pyvlx.api.frame_creation import frame_from_raw
-from pyvlx.api.frames import FrameCommandRunStatusNotification
+from pyvlx.api.frames import FrameCommandRunStatusNotification, CommandNotificationRunStatus, CommandNotificationStatusReply
 
 
 class TestFrameCommandRunStatusNotification(unittest.TestCase):
@@ -11,7 +11,7 @@ class TestFrameCommandRunStatusNotification(unittest.TestCase):
     # pylint: disable=too-many-public-methods,invalid-name
 
     EXAMPLE_FRAME = (
-        b"\x00\x10\x03\x02\x03\xe8\x07\x17*\x059\x00\x00\x00\x00\x00\x00\xfc"
+        b"\x00\x10\x03\x02\x03\xe8\x07\x17*\x059\x01\xe3\x00\x00\x00\x00\x1e"
     )
 
     def test_bytes(self):
@@ -22,6 +22,8 @@ class TestFrameCommandRunStatusNotification(unittest.TestCase):
             index_id=23,
             node_parameter=42,
             parameter_value=1337,
+            run_status=CommandNotificationRunStatus.EXECUTION_FAILED,
+            status_reply=CommandNotificationStatusReply.LIMITATION_BY_RAIN,
         )
         self.assertEqual(bytes(frame), self.EXAMPLE_FRAME)
 
@@ -34,6 +36,8 @@ class TestFrameCommandRunStatusNotification(unittest.TestCase):
         self.assertEqual(frame.index_id, 23)
         self.assertEqual(frame.node_parameter, 42)
         self.assertEqual(frame.parameter_value, 1337)
+        self.assertEqual(frame.run_status, CommandNotificationRunStatus.EXECUTION_FAILED)
+        self.assertEqual(frame.status_reply, CommandNotificationStatusReply.LIMITATION_BY_RAIN)
 
     def test_str(self):
         """Test string representation of FrameCommandRunStatusNotification."""
@@ -43,8 +47,12 @@ class TestFrameCommandRunStatusNotification(unittest.TestCase):
             index_id=23,
             node_parameter=42,
             parameter_value=1337,
+            run_status=CommandNotificationRunStatus.EXECUTION_FAILED,
+            status_reply=CommandNotificationStatusReply.LIMITATION_BY_RAIN,
         )
         self.assertEqual(
             str(frame),
-            '<FrameCommandRunStatusNotification session_id="1000" status_id="7" index_id="23" node_parameter="42" parameter_value="1337"/>',
+            '<FrameCommandRunStatusNotification session_id="1000" status_id="7" index_id="23" node_parameter="42" '
+            'parameter_value="1337" run_status="CommandNotificationRunStatus.EXECUTION_FAILED" '
+            'status_reply="CommandNotificationStatusReply.LIMITATION_BY_RAIN"/>',
         )


### PR DESCRIPTION
GW_COMMAND_RUN_STATUS_NTF StatusReply can provide a lot of useful debugging information (e.g. opening of the window was blocked by rain sensor).

Feel free to make any edits to the commit before merging.

Thank you for a great Velux integration library!