### PR TITLE
Dont set actual position from command

### DIFF
--- a/pyvlx/opening_device.py
+++ b/pyvlx/opening_device.py
@@ -313,7 +313,6 @@ class Blind(OpeningDevice):
 
         """
         self.target_position = position
-        self.position = position
         kwargs: Any = {}
 
         if orientation is not None:


### PR DESCRIPTION
Setting actual position from set_possition_command cannot be used, as target_position values can be out of range, in example if stop commands are submitted. Instead we should wait for the KLF200 to report the actual position.

This PR has been tested and it solves: https://github.com/pawlizio/my_velux/issues/69 