### PR TITLE
fix recognition of status closed 

### DIFF
--- a/pyvlx/parameter.py
+++ b/pyvlx/parameter.py
@@ -216,7 +216,7 @@ class Position(Parameter):
     def closed(self) -> bool:
         """Return true if position is set to fully closed."""
         # Consider closed even if raw is not exactly 51200 (tolerance for devices like Velux SML)
-        return self.raw == self.from_int(Position.MAX)
+        return self.to_percent(self.raw) == self.to_percent(self.from_int(Position.MAX))
 
     @property
     def position(self) -> int:

--- a/test/position_test.py
+++ b/test/position_test.py
@@ -43,6 +43,9 @@ class TestPosition(unittest.TestCase):
         self.assertEqual(Position(Parameter(raw=b"\x0A\x05")).position, 2565)
         self.assertEqual(Position(position_percent=50).position, 25600)
         self.assertEqual(Position(position=12345).position_percent, 24)
+        self.assertEqual(Position(position=51200).position_percent, 100)
+        # test tolerance for devices that report positions only close to 100% 
+        self.assertEqual(Position(position=51160).position_percent, 100)
 
     def test_fallback_to_unknown(self) -> None:
         """Test fallback to unknown."""
@@ -85,6 +88,12 @@ class TestPosition(unittest.TestCase):
         self.assertFalse(position_open.closed)
         self.assertTrue(position_open.open)
         position_closed = Position(position_percent=100)
+        self.assertTrue(position_closed.closed)
+        self.assertFalse(position_closed.open)
+        position_closed = Position(position=51200)
+        self.assertTrue(position_closed.closed)
+        self.assertFalse(position_closed.open)
+        position_closed = Position(position=51160)
         self.assertTrue(position_closed.closed)
         self.assertFalse(position_closed.open)
         position_half = Position(position_percent=50)


### PR DESCRIPTION
The library already has code for some covers that report values only close to 0xC800 when at 100%, but the code for reporting a status == closed broke with commit https://github.com/Julius2342/pyvlx/commit/46992b4637d1163157d76e7ca2bb377882124f55
This PR fixes the regression and adds tests for it. 