### PR TITLE
Refactor node_helper

### DIFF
--- a/src/pyvlx/node_helper.py
+++ b/src/pyvlx/node_helper.py
@@ -1,5 +1,5 @@
 """Helper module for Node objects."""
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 from .api.frames import (
     FrameGetAllNodesInformationNotification,
@@ -17,164 +17,78 @@ if TYPE_CHECKING:
     from pyvlx import PyVLX
 
 
+FrameNodeInformation = Union[
+    FrameGetNodeInformationNotification, FrameGetAllNodesInformationNotification
+]
+NodeFactory = Callable[["PyVLX", FrameNodeInformation], Node]
+
+
+def _base_kwargs(
+    pyvlx: "PyVLX", frame: FrameNodeInformation
+) -> dict[str, Any]:
+    """Return constructor kwargs shared by all node types."""
+    return {
+        "pyvlx": pyvlx,
+        "node_id": frame.node_id,
+        "name": frame.name,
+        "serial_number": frame.serial_number,
+    }
+
+
+def _node_factory(
+    node_constructor: Callable[..., Node],
+    *,
+    use_position: bool = True,
+    rain_sensor: bool | None = None,
+) -> NodeFactory:
+    """Build a factory for node constructors with optional extras."""
+
+    def _factory(pyvlx: "PyVLX", frame: FrameNodeInformation) -> Node:
+        kwargs = _base_kwargs(pyvlx=pyvlx, frame=frame)
+        if use_position:
+            kwargs["position_parameter"] = frame.current_position
+        if rain_sensor is not None:
+            kwargs["rain_sensor"] = rain_sensor
+        return node_constructor(**kwargs)
+
+    return _factory
+
+
+NODE_FACTORY: dict[NodeTypeWithSubtype, NodeFactory] = {
+    NodeTypeWithSubtype.WINDOW_OPENER: _node_factory(Window, rain_sensor=False),
+    NodeTypeWithSubtype.WINDOW_OPENER_WITH_RAIN_SENSOR: _node_factory(Window, rain_sensor=True),
+    NodeTypeWithSubtype.DUAL_ROLLER_SHUTTER: _node_factory(DualRollerShutter),
+    NodeTypeWithSubtype.ROLLER_SHUTTER: _node_factory(RollerShutter),
+    NodeTypeWithSubtype.SWINGING_SHUTTERS: _node_factory(RollerShutter),
+    # Unclear why the next two do not have position, possibly just an oversight when introduced initially
+    NodeTypeWithSubtype.VERTICAL_INTERIOR_BLINDS: _node_factory(RollerShutter, use_position=False),
+    NodeTypeWithSubtype.INTERIOR_VENETIAN_BLIND: _node_factory(RollerShutter, use_position=False),
+    NodeTypeWithSubtype.EXTERIOR_VENETIAN_BLIND: _node_factory(Blind),
+    NodeTypeWithSubtype.ADJUSTABLE_SLATS_ROLLING_SHUTTER: _node_factory(Blind),
+    NodeTypeWithSubtype.LOUVER_BLIND: _node_factory(Blind),
+    NodeTypeWithSubtype.VERTICAL_EXTERIOR_AWNING: _node_factory(Awning),
+    NodeTypeWithSubtype.HORIZONTAL_AWNING: _node_factory(Awning),
+    NodeTypeWithSubtype.HORIZONTAL_AWNING_ALT: _node_factory(Awning),
+    NodeTypeWithSubtype.GARAGE_DOOR_OPENER: _node_factory(GarageDoor),
+    NodeTypeWithSubtype.LINEAR_ANGULAR_POSITION_OF_GARAGE_DOOR: _node_factory(GarageDoor),
+    NodeTypeWithSubtype.GATE_OPENER: _node_factory(Gate),
+    NodeTypeWithSubtype.GATE_OPENER_ANGULAR_POSITION: _node_factory(Gate),
+    NodeTypeWithSubtype.BLADE_OPENER: _node_factory(Blade),
+    NodeTypeWithSubtype.ON_OFF_SWITCH: _node_factory(OnOffSwitch, use_position=False),
+    NodeTypeWithSubtype.LIGHT: _node_factory(Light, use_position=False),
+    NodeTypeWithSubtype.LIGHT_ON_OFF: _node_factory(OnOffLight, use_position=False),
+    NodeTypeWithSubtype.EXTERIOR_HEATING: _node_factory(ExteriorHeating, use_position=False),
+}
+
+
 def convert_frame_to_node(
     pyvlx: "PyVLX",
-    frame: Union[
-        FrameGetNodeInformationNotification, FrameGetAllNodesInformationNotification
-    ],
-) -> Optional[Node]:
+    frame: FrameNodeInformation,
+) -> Node | None:
     """Convert FrameGet[All]Node[s]InformationNotification into Node object."""
-    # pylint: disable=too-many-return-statements
-
-    if frame.node_type == NodeTypeWithSubtype.WINDOW_OPENER:
-        return Window(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-            rain_sensor=False,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.WINDOW_OPENER_WITH_RAIN_SENSOR:
-        return Window(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-            rain_sensor=True,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.DUAL_ROLLER_SHUTTER:
-        return DualRollerShutter(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type in [
-        NodeTypeWithSubtype.ROLLER_SHUTTER,
-        NodeTypeWithSubtype.SWINGING_SHUTTERS,
-    ]:
-        return RollerShutter(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type in [
-        NodeTypeWithSubtype.VERTICAL_INTERIOR_BLINDS,
-        NodeTypeWithSubtype.INTERIOR_VENETIAN_BLIND,
-    ]:
-        return RollerShutter(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-        )
-
-    # Blinds have position and orientation (inherit frame.current_position_fp3) attribute
-    if frame.node_type in [
-        NodeTypeWithSubtype.EXTERIOR_VENETIAN_BLIND,
-        NodeTypeWithSubtype.ADJUSTABLE_SLATS_ROLLING_SHUTTER,
-        NodeTypeWithSubtype.LOUVER_BLIND,
-    ]:
-        return Blind(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type in [
-        NodeTypeWithSubtype.VERTICAL_EXTERIOR_AWNING,
-        NodeTypeWithSubtype.HORIZONTAL_AWNING,
-        NodeTypeWithSubtype.HORIZONTAL_AWNING_ALT,
-    ]:
-        return Awning(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.ON_OFF_SWITCH:
-        return OnOffSwitch(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-        )
-
-    if frame.node_type in [
-        NodeTypeWithSubtype.GARAGE_DOOR_OPENER,
-        NodeTypeWithSubtype.LINEAR_ANGULAR_POSITION_OF_GARAGE_DOOR,
-    ]:
-        return GarageDoor(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.GATE_OPENER:
-        return Gate(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.GATE_OPENER_ANGULAR_POSITION:
-        return Gate(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.BLADE_OPENER:
-        return Blade(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-            position_parameter=frame.current_position,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.LIGHT:
-        return Light(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.LIGHT_ON_OFF:
-        return OnOffLight(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-        )
-
-    if frame.node_type == NodeTypeWithSubtype.EXTERIOR_HEATING:
-        return ExteriorHeating(
-            pyvlx=pyvlx,
-            node_id=frame.node_id,
-            name=frame.name,
-            serial_number=frame.serial_number,
-        )
+    factory = NODE_FACTORY.get(frame.node_type)
+    if factory is not None:
+        return factory(pyvlx, frame)
 
     PYVLXLOG.warning("%s not implemented", frame.node_type)
     return None

--- a/test/node_helper_test.py
+++ b/test/node_helper_test.py
@@ -193,6 +193,15 @@ class TestNodeHelper(unittest.TestCase):
         frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
         self.assertEqual(convert_frame_to_node(self.pyvlx, frame), None)
 
+    def test_unknown_node_type(self) -> None:
+        """Test convert_frame_to_node with an unknown node type value."""
+        frame = FrameGetNodeInformationNotification()
+        frame.node_id = 23
+        frame.name = "Fnord23"
+        frame.node_type = 99999  # unknown node type value (not in NodeTypeWithSubtype)
+        frame.serial_number = "aa:bb:aa:bb:aa:bb:aa:23"
+        self.assertEqual(convert_frame_to_node(self.pyvlx, frame), None)
+
     def test_light(self) -> None:
         """Test convert_frame_to_node with light."""
         frame = FrameGetNodeInformationNotification()


### PR DESCRIPTION
This PR refactors the repetitive code in node_helper into a lookup dict plus factory method. The existing tests still pass. The PR keeps the current behaviour for `INTERIOR_VENETIAN_BLIND` and `VERTICAL_INTERIOR_BLIND` which unlike all other `RollerShutter` devices get created without passing in the current position from the frame. I suspect this was an oversight when added back then but as I don't know, I did not change it. The PR also adds one additional test that ensures unknown node types return None (but don't raise). 