### PR TITLE
Preserve movement state during executing frames with unavailable positions

### DIFF
--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -40,6 +40,11 @@ class NodeUpdater:
         """Initialize NodeUpdater object."""
         self.pyvlx = pyvlx
 
+    @staticmethod
+    def _has_concrete_position(position: Position) -> bool:
+        """Return True when a position can be used for movement comparisons."""
+        return position.position <= Parameter.MAX
+
     async def process_frame_status_request_notification(
         self, frame: FrameStatusRequestNotification
     ) -> None:
@@ -98,12 +103,25 @@ class NodeUpdater:
 
         position = Position(frame.current_position)
         target = Position(frame.target)
+        position_is_concrete = self._has_concrete_position(position)
+        target_is_concrete = self._has_concrete_position(target)
+        frame_indicates_motion = (
+            frame.state == OperatingState.EXECUTING
+            or frame.remaining_time > 0
+        )
+
+        comparison_position = position
+        if not position_is_concrete and self._has_concrete_position(node.position):
+            comparison_position = node.position
+            position_is_concrete = True
 
         node_changed = False
 
-        if (position.position <= Parameter.MAX and position.position > target.position and target.position <= Parameter.MAX) and (
-            (frame.state == OperatingState.EXECUTING)
-            or frame.remaining_time > 0
+        if (
+            position_is_concrete
+            and target_is_concrete
+            and comparison_position.position > target.position
+            and frame_indicates_motion
         ):
             node_changed |= _set_node_property(node, "is_opening", True)
             node_changed |= _set_node_property(node, "is_closing", False)
@@ -114,14 +132,16 @@ class NodeUpdater:
             )
             PYVLXLOG.debug(
                 "%s is opening (%s->%s), estimated completion in %ss at %s",
-                node.name, position, target,
+                node.name, comparison_position, target,
                 frame.remaining_time,
                 node.estimated_completion.strftime("%Y-%m-%d %H:%M:%S")
             )
 
-        elif (position.position < target.position <= Parameter.MAX) and (
-            (frame.state == OperatingState.EXECUTING)
-            or frame.remaining_time > 0
+        elif (
+            position_is_concrete
+            and target_is_concrete
+            and comparison_position.position < target.position
+            and frame_indicates_motion
         ):
             node_changed |= _set_node_property(node, "is_closing", True)
             node_changed |= _set_node_property(node, "is_opening", False)
@@ -132,9 +152,25 @@ class NodeUpdater:
             )
             PYVLXLOG.debug(
                 "%s is closing (%s->%s), estimated completion in %ss at %s",
-                node.name, position, target,
+                node.name, comparison_position, target,
                 frame.remaining_time,
                 node.estimated_completion.strftime("%Y-%m-%d %H:%M:%S")
+            )
+
+        elif frame_indicates_motion and target_is_concrete and (node.is_opening or node.is_closing):
+            node.state_received_at = datetime.datetime.now()
+            node.estimated_completion = (
+                node.state_received_at
+                + datetime.timedelta(0, frame.remaining_time)
+            )
+            PYVLXLOG.debug(
+                "%s keeps previous motion state while current position is unavailable (%s->%s),"
+                " estimated completion in %ss at %s",
+                node.name,
+                position,
+                target,
+                frame.remaining_time,
+                node.estimated_completion.strftime("%Y-%m-%d %H:%M:%S"),
             )
 
         else:

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -447,6 +447,107 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertTrue(device.is_closing)
         device.after_update.assert_awaited_once()
 
+    async def test_is_opening_preserved_when_current_position_is_ignore_while_executing(self) -> None:
+        """Test that executing frames with IGNORE do not clear an active opening state."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=70, name="Test gate"
+        )
+        device.position = Position(position_percent=100)
+        device.target = Position(position_percent=0)
+        device.is_opening = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[70] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 70
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.IGNORE)
+        frame.target = Position(position_percent=0)
+        frame.remaining_time = 3
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        device.after_update.assert_not_awaited()
+
+    async def test_is_closing_preserved_when_current_position_is_unknown_while_executing(self) -> None:
+        """Test that executing frames with UNKNOWN do not clear an active closing state."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=71, name="Test gate"
+        )
+        device.position = Position(position_percent=0)
+        device.target = Position(position_percent=100)
+        device.is_closing = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[71] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 71
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=100)
+        frame.remaining_time = 3
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_closing)
+        self.assertFalse(device.is_opening)
+        device.after_update.assert_not_awaited()
+
+    async def test_motion_direction_derived_from_cached_position_when_frame_position_unknown(self) -> None:
+        """Frames with IGNORE/UNKNOWN current_position should derive direction from the cached node position."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=72, name="Test gate"
+        )
+        device.position = Position(position_percent=100)
+        device.target = Position(position_percent=0)
+        device.is_opening = False
+        device.is_closing = False
+        device.last_frame_state = OperatingState.NON_EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[72] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 72
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=0)
+        frame.remaining_time = 5
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        device.after_update.assert_awaited_once()
+
+    async def test_idle_device_stays_idle_when_frame_position_unknown(self) -> None:
+        """An idle device must not be marked as moving when the frame position is unavailable."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=73, name="Test gate"
+        )
+        device.position = Position(position=Parameter.UNKNOWN_VALUE)
+        device.target = Position(position_percent=50)
+        device.is_opening = False
+        device.is_closing = False
+        device.last_frame_state = OperatingState.NON_EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[73] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 73
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=50)
+        frame.remaining_time = 5
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(device.is_opening)
+        self.assertFalse(device.is_closing)
+
     async def test_after_update_called_when_last_frame_state_changes(self) -> None:
         """Test that after_update() is called when last_frame_state changes."""
         device = OpeningDevice(

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -447,8 +447,8 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertTrue(device.is_closing)
         device.after_update.assert_awaited_once()
 
-    async def test_is_opening_preserved_when_current_position_is_ignore_while_executing(self) -> None:
-        """Test that executing frames with IGNORE do not clear an active opening state."""
+    async def test_is_opening_kept_via_cached_position_when_frame_current_position_is_ignore(self) -> None:
+        """IGNORE current_position should fall back to the cached node position and keep is_opening set."""
         device = OpeningDevice(
             pyvlx=self.pyvlx, node_id=70, name="Test gate"
         )
@@ -472,8 +472,8 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertFalse(device.is_closing)
         device.after_update.assert_not_awaited()
 
-    async def test_is_closing_preserved_when_current_position_is_unknown_while_executing(self) -> None:
-        """Test that executing frames with UNKNOWN do not clear an active closing state."""
+    async def test_is_closing_kept_via_cached_position_when_frame_current_position_is_unknown(self) -> None:
+        """UNKNOWN current_position should fall back to the cached node position and keep is_closing set."""
         device = OpeningDevice(
             pyvlx=self.pyvlx, node_id=71, name="Test gate"
         )
@@ -495,6 +495,60 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertTrue(device.is_closing)
         self.assertFalse(device.is_opening)
+        device.after_update.assert_not_awaited()
+
+    async def test_motion_state_preserved_when_cached_and_frame_positions_are_both_unavailable(self) -> None:
+        """If neither the cached nor the frame position is concrete, an active motion state is preserved."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=74, name="Test gate"
+        )
+        device.position = Position(position=Parameter.UNKNOWN_VALUE)
+        device.target = Position(position_percent=50)
+        device.is_opening = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[74] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 74
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=50)
+        frame.remaining_time = 4
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
+        device.after_update.assert_not_awaited()
+
+    async def test_motion_state_preserved_when_current_position_equals_target_while_executing(self) -> None:
+        """Executing frames where current_position == target must not clear an active motion state."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=75, name="Test gate"
+        )
+        device.position = Position(position_percent=50)
+        device.target = Position(position_percent=50)
+        device.is_opening = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[75] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 75
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position_percent=50)
+        frame.target = Position(position_percent=50)
+        frame.remaining_time = 2
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()
 
     async def test_motion_direction_derived_from_cached_position_when_frame_position_unknown(self) -> None:

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -520,6 +520,7 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertTrue(device.is_opening)
         self.assertFalse(device.is_closing)
+        self.assertEqual(device.position, Position(position=Parameter.UNKNOWN_VALUE))
         self.assertIsNotNone(device.state_received_at)
         self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()
@@ -547,6 +548,7 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertTrue(device.is_closing)
         self.assertFalse(device.is_opening)
+        self.assertEqual(device.position, Position(position=Parameter.UNKNOWN_VALUE))
         self.assertIsNotNone(device.state_received_at)
         self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -551,6 +551,60 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()
 
+    async def test_closing_state_preserved_when_cached_and_frame_positions_are_both_unavailable(self) -> None:
+        """If neither cached nor frame position is concrete, an active closing state is preserved too."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=76, name="Test gate"
+        )
+        device.position = Position(position=Parameter.UNKNOWN_VALUE)
+        device.target = Position(position_percent=50)
+        device.is_closing = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[76] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 76
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=50)
+        frame.remaining_time = 4
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_closing)
+        self.assertFalse(device.is_opening)
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
+        device.after_update.assert_not_awaited()
+
+    async def test_closing_state_preserved_when_current_position_equals_target_while_executing(self) -> None:
+        """Executing frames where current_position == target must not clear an active closing state either."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=77, name="Test gate"
+        )
+        device.position = Position(position_percent=50)
+        device.target = Position(position_percent=50)
+        device.is_closing = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[77] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 77
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position_percent=50)
+        frame.target = Position(position_percent=50)
+        frame.remaining_time = 2
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_closing)
+        self.assertFalse(device.is_opening)
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
+        device.after_update.assert_not_awaited()
+
     async def test_motion_direction_derived_from_cached_position_when_frame_position_unknown(self) -> None:
         """Frames with IGNORE/UNKNOWN current_position should derive direction from the cached node position."""
         device = OpeningDevice(

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -498,7 +498,7 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         device.after_update.assert_not_awaited()
 
     async def test_motion_state_preserved_when_cached_and_frame_positions_are_both_unavailable(self) -> None:
-        """If neither the cached nor the frame position is concrete, an active motion state is preserved."""
+        """If neither the cached nor the frame position is concrete, an active opening state is preserved."""
         device = OpeningDevice(
             pyvlx=self.pyvlx, node_id=74, name="Test gate"
         )
@@ -515,33 +515,6 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
         frame.target = Position(position_percent=50)
         frame.remaining_time = 4
-
-        await self.node_updater.process_frame(frame)
-
-        self.assertTrue(device.is_opening)
-        self.assertFalse(device.is_closing)
-        self.assertIsNotNone(device.state_received_at)
-        self.assertIsNotNone(device.estimated_completion)
-        device.after_update.assert_not_awaited()
-
-    async def test_motion_state_preserved_when_current_position_equals_target_while_executing(self) -> None:
-        """Executing frames where current_position == target must not clear an active motion state."""
-        device = OpeningDevice(
-            pyvlx=self.pyvlx, node_id=75, name="Test gate"
-        )
-        device.position = Position(position_percent=50)
-        device.target = Position(position_percent=50)
-        device.is_opening = True
-        device.last_frame_state = OperatingState.EXECUTING
-        device.after_update = AsyncMock()  # type: ignore[method-assign]
-        self.pyvlx.nodes[75] = device
-
-        frame = FrameNodeStatePositionChangedNotification()
-        frame.node_id = 75
-        frame.state = OperatingState.EXECUTING
-        frame.current_position = Position(position_percent=50)
-        frame.target = Position(position_percent=50)
-        frame.remaining_time = 2
 
         await self.node_updater.process_frame(frame)
 
@@ -578,6 +551,34 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()
 
+    async def test_motion_state_preserved_when_current_position_equals_target_while_executing(self) -> None:
+        """Executing frames where current_position == target must not clear an active opening state."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=75, name="Test gate"
+        )
+        device.position = Position(position_percent=50)
+        device.target = Position(position_percent=50)
+        device.is_opening = True
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[75] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 75
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position_percent=50)
+        frame.target = Position(position_percent=50)
+        frame.remaining_time = 2
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertEqual(device.position, Position(position_percent=50))
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
+        device.after_update.assert_not_awaited()
+
     async def test_closing_state_preserved_when_current_position_equals_target_while_executing(self) -> None:
         """Executing frames where current_position == target must not clear an active closing state either."""
         device = OpeningDevice(
@@ -601,6 +602,7 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertTrue(device.is_closing)
         self.assertFalse(device.is_opening)
+        self.assertEqual(device.position, Position(position_percent=50))
         self.assertIsNotNone(device.state_received_at)
         self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()


### PR DESCRIPTION
Fixes #666 

## Motivation

Observed on a Somfy Control BOX 3S io gate behind a KLF200: while the gate was closing, Home Assistant briefly reported the cover as "opening" before flipping back to "closing". Root cause is that `FrameNodeStatePositionChangedNotification` frames emitted during active motion sometimes carry `current_position = IGNORE` / `UNKNOWN_VALUE`.
The previous logic treated those as "no direction" and cleared `is_opening` / `is_closing`, even though `OperatingState.EXECUTING` and `remaining_time` still indicated motion.

## Summary

- fall back to the cached node position when EXECUTING frames report
  IGNORE or UNKNOWN current positions
- preserve the previous opening or closing state when the frame still
  indicates motion but direction cannot be derived
- expand regression coverage for the preserve branch, including both
  motion directions and unchanged cached positions

## Testing

- `.venv/bin/pytest -q test/node_updater_test.py`
