### PR TITLE
Drop stale after_update() in OpeningDevice.set_position

### DIFF
--- a/src/pyvlx/opening_device.py
+++ b/src/pyvlx/opening_device.py
@@ -115,7 +115,6 @@ class OpeningDevice(Node):
             timeout_in_seconds=timeout_in_seconds,
         )
         await command.send()
-        await self.after_update()
 
     async def open(
         self,

--- a/test/opening_device_test.py
+++ b/test/opening_device_test.py
@@ -19,12 +19,12 @@ class TestOpeningDevice(IsolatedAsyncioTestCase):
 
     @patch("pyvlx.api.CommandSend.send", new_callable=AsyncMock)
     @patch("pyvlx.Node.after_update", new_callable=AsyncMock)
-    async def test_set_position(self, command_send: AsyncMock, after_update: AsyncMock) -> None:
-        """Test set_position of OpeningDevice object."""
+    async def test_set_position(self, after_update: AsyncMock, command_send: AsyncMock) -> None:
+        """Test set_position sends the command without publishing a stale update first."""
         opening_device = OpeningDevice(pyvlx=self.mocked_pyvlx, node_id=23, name="Test device")
         await opening_device.set_position(position=Position(position_percent=100))
-        assert command_send.called
-        assert after_update.called
+        command_send.assert_awaited_once()
+        after_update.assert_not_awaited()
 
     @patch("pyvlx.opening_device.OpeningDevice.set_position", new_callable=AsyncMock)
     async def test_open(self, set_position: AsyncMock) -> None:
@@ -66,7 +66,7 @@ class TestOpeningDevice(IsolatedAsyncioTestCase):
     @patch("pyvlx.opening_device.CommandSend")
     @patch("pyvlx.Node.after_update", new_callable=AsyncMock)
     async def test_set_position_forwards_timeout(self, after_update: AsyncMock, mock_command_send: MagicMock) -> None:
-        """Test set_position forwards timeout_in_seconds to CommandSend when provided."""
+        """Test set_position forwards timeout_in_seconds without triggering an immediate callback."""
         opening_device = OpeningDevice(pyvlx=self.mocked_pyvlx, node_id=23, name="Test device")
         command_instance = MagicMock()
         command_instance.send = AsyncMock()
@@ -80,12 +80,12 @@ class TestOpeningDevice(IsolatedAsyncioTestCase):
 
         self.assertEqual(mock_command_send.call_args.kwargs["timeout_in_seconds"], 7)
         command_instance.send.assert_awaited_once()
-        after_update.assert_awaited_once()
+        after_update.assert_not_awaited()
 
     @patch("pyvlx.opening_device.CommandSend")
     @patch("pyvlx.Node.after_update", new_callable=AsyncMock)
     async def test_set_position_uses_default_timeout_when_not_provided(self, after_update: AsyncMock, mock_command_send: MagicMock) -> None:
-        """Test set_position applies the CommandSend default timeout when not provided."""
+        """Test set_position applies the default timeout without publishing a stale update."""
         opening_device = OpeningDevice(pyvlx=self.mocked_pyvlx, node_id=23, name="Test device")
         command_instance = MagicMock()
         command_instance.send = AsyncMock()
@@ -95,7 +95,7 @@ class TestOpeningDevice(IsolatedAsyncioTestCase):
 
         self.assertEqual(mock_command_send.call_args.kwargs["timeout_in_seconds"], 2)
         command_instance.send.assert_awaited_once()
-        after_update.assert_awaited_once()
+        after_update.assert_not_awaited()
 
     @patch("pyvlx.opening_device.SetLimitation")
     @patch("pyvlx.Node.after_update", new_callable=AsyncMock)


### PR DESCRIPTION
Fixes #667

## Motivation

Discovered while debugging the motion-state issue on a Somfy Control BOX 3S io gate (#665 / #666 ): `OpeningDevice.set_position` awaits `self.after_update()` right after `command.send()`, but no local attribute has been mutated at that point. `position`, `target`, `is_opening` and `is_closing` are only updated later by `NodeUpdater`
when frames arrive from the KLF200. Consumers were therefore notified of a "change" when nothing had actually changed yet.

All other send-paths in `opening_device.py` mutate local state before firing `after_update()` (`set_position_limitations`,
`clear_position_limitations`, `Blind.set_position_and_orientation`, `Blind.set_orientation`, `DualRollerShutter.set_position`). Only `OpeningDevice.set_position` was out of line.

## Summary

- drop the stale `await self.after_update()` in `OpeningDevice.set_position`; the real state change is announced via
  the frame-driven update path in `NodeUpdater` once the KLF200  responds
- fix the `@patch` argument order in `test_set_position`: decorators  stack bottom-up, so the innermost patch (`Node.after_update`) binds  to the first positional argument — the previous order had `command_send` and `after_update` swapped, which made the existing `.called` assertions pass against the wrong mocks by accident
- switch the affected tests from `.called` to `assert_awaited_once()`  and `assert_not_awaited()` so they also catch duplicate awaits and  reflect the new semantics

## Testing

- `.venv/bin/pytest -q test/`