### PR TITLE
Derive opening-device direction from target changes

### DIFF
--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -104,7 +104,7 @@ class NodeUpdater:
         position = Position(frame.current_position)
         target = Position(frame.target)
         frame_position_is_concrete = self._has_concrete_position(position)
-        position_is_concrete = frame_position_is_concrete
+        comparison_position_is_concrete = frame_position_is_concrete
         target_is_concrete = self._has_concrete_position(target)
         frame_indicates_motion = (
             frame.state == OperatingState.EXECUTING
@@ -112,14 +112,14 @@ class NodeUpdater:
         )
 
         comparison_position = position
-        if not position_is_concrete and self._has_concrete_position(node.position):
+        if not comparison_position_is_concrete and self._has_concrete_position(node.position):
             comparison_position = node.position
-            position_is_concrete = True
+            comparison_position_is_concrete = True
 
         node_changed = False
 
         if (
-            position_is_concrete
+            comparison_position_is_concrete
             and target_is_concrete
             and comparison_position.position > target.position
             and frame_indicates_motion
@@ -139,7 +139,7 @@ class NodeUpdater:
             )
 
         elif (
-            position_is_concrete
+            comparison_position_is_concrete
             and target_is_concrete
             and comparison_position.position < target.position
             and frame_indicates_motion
@@ -165,6 +165,7 @@ class NodeUpdater:
             and node.target != target
             and frame_indicates_motion
         ):
+            # node.target is updated in _update_node_main_parameter after this method returns.
             if node.target.position > target.position:
                 node_changed |= _set_node_property(node, "is_opening", True)
                 node_changed |= _set_node_property(node, "is_closing", False)
@@ -232,10 +233,10 @@ class NodeUpdater:
                 frame.state == OperatingState.EXECUTING
                 or frame.remaining_time > 0
             )
-            if position.position <= Parameter.MAX:
+            if self._has_concrete_position(position):
                 node_changed |= _set_node_property(node, "position", position)
                 node_changed |= _set_node_property(node, "target", target)
-            elif target.position <= Parameter.MAX and frame_indicates_motion:
+            elif self._has_concrete_position(target) and frame_indicates_motion:
                 node_changed |= _set_node_property(node, "target", target)
 
         if isinstance(node, DimmableDevice):

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -103,7 +103,8 @@ class NodeUpdater:
 
         position = Position(frame.current_position)
         target = Position(frame.target)
-        position_is_concrete = self._has_concrete_position(position)
+        frame_position_is_concrete = self._has_concrete_position(position)
+        position_is_concrete = frame_position_is_concrete
         target_is_concrete = self._has_concrete_position(target)
         frame_indicates_motion = (
             frame.state == OperatingState.EXECUTING
@@ -157,6 +158,34 @@ class NodeUpdater:
                 node.estimated_completion.strftime("%Y-%m-%d %H:%M:%S")
             )
 
+        elif (
+            not frame_position_is_concrete
+            and target_is_concrete
+            and self._has_concrete_position(node.target)
+            and node.target != target
+            and frame_indicates_motion
+        ):
+            if node.target.position > target.position:
+                node_changed |= _set_node_property(node, "is_opening", True)
+                node_changed |= _set_node_property(node, "is_closing", False)
+            else:
+                node_changed |= _set_node_property(node, "is_closing", True)
+                node_changed |= _set_node_property(node, "is_opening", False)
+            node.state_received_at = datetime.datetime.now()
+            node.estimated_completion = (
+                node.state_received_at
+                + datetime.timedelta(0, frame.remaining_time)
+            )
+            PYVLXLOG.debug(
+                "%s changed motion target while current position is unavailable (%s->%s),"
+                " estimated completion in %ss at %s",
+                node.name,
+                node.target,
+                target,
+                frame.remaining_time,
+                node.estimated_completion.strftime("%Y-%m-%d %H:%M:%S"),
+            )
+
         elif frame_indicates_motion and target_is_concrete and (node.is_opening or node.is_closing):
             node.state_received_at = datetime.datetime.now()
             node.estimated_completion = (
@@ -199,8 +228,14 @@ class NodeUpdater:
         if isinstance(node, OpeningDevice):
             position = Position(frame.current_position)
             target = Position(frame.target)
+            frame_indicates_motion = (
+                frame.state == OperatingState.EXECUTING
+                or frame.remaining_time > 0
+            )
             if position.position <= Parameter.MAX:
                 node_changed |= _set_node_property(node, "position", position)
+                node_changed |= _set_node_property(node, "target", target)
+            elif target.position <= Parameter.MAX and frame_indicates_motion:
                 node_changed |= _set_node_property(node, "target", target)
 
         if isinstance(node, DimmableDevice):

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -41,7 +41,7 @@ class NodeUpdater:
         self.pyvlx = pyvlx
 
     @staticmethod
-    def _has_concrete_position(position: Position) -> bool:
+    def _is_concrete_position(position: Position) -> bool:
         """Return True when a position can be used for movement comparisons."""
         return position.position <= Parameter.MAX
 
@@ -103,16 +103,16 @@ class NodeUpdater:
 
         position = Position(frame.current_position)
         target = Position(frame.target)
-        frame_position_is_concrete = self._has_concrete_position(position)
+        frame_position_is_concrete = self._is_concrete_position(position)
         comparison_position_is_concrete = frame_position_is_concrete
-        target_is_concrete = self._has_concrete_position(target)
+        target_is_concrete = self._is_concrete_position(target)
         frame_indicates_motion = (
             frame.state == OperatingState.EXECUTING
             or frame.remaining_time > 0
         )
 
         comparison_position = position
-        if not comparison_position_is_concrete and self._has_concrete_position(node.position):
+        if not comparison_position_is_concrete and self._is_concrete_position(node.position):
             comparison_position = node.position
             comparison_position_is_concrete = True
 
@@ -161,7 +161,7 @@ class NodeUpdater:
         elif (
             not frame_position_is_concrete
             and target_is_concrete
-            and self._has_concrete_position(node.target)
+            and self._is_concrete_position(node.target)
             and node.target != target
             and frame_indicates_motion
         ):
@@ -233,10 +233,10 @@ class NodeUpdater:
                 frame.state == OperatingState.EXECUTING
                 or frame.remaining_time > 0
             )
-            if self._has_concrete_position(position):
+            if self._is_concrete_position(position):
                 node_changed |= _set_node_property(node, "position", position)
                 node_changed |= _set_node_property(node, "target", target)
-            elif self._has_concrete_position(target) and frame_indicates_motion:
+            elif self._is_concrete_position(target) and frame_indicates_motion:
                 node_changed |= _set_node_property(node, "target", target)
 
         if isinstance(node, DimmableDevice):

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -720,6 +720,138 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertFalse(device.is_opening)
         self.assertFalse(device.is_closing)
 
+    async def test_gate_opening_live_sequence_keeps_direction_until_done(self) -> None:
+        """Live gate sequence should keep opening through IGNORE frames and stop on DONE."""
+        device = OpeningDevice(pyvlx=self.pyvlx, node_id=80, name="Test gate")
+        device.position = Position(position_percent=100)
+        device.target = Position(position_percent=100)
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[80] = device
+
+        start_frame = FrameNodeStatePositionChangedNotification()
+        start_frame.node_id = 80
+        start_frame.state = OperatingState.EXECUTING
+        start_frame.current_position = Position(position_percent=100)
+        start_frame.target = Position(position_percent=0)
+        start_frame.remaining_time = 1
+
+        await self.node_updater.process_frame(start_frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertEqual(device.position, Position(position_percent=100))
+        self.assertEqual(device.target, Position(position_percent=0))
+
+        for _ in range(2):
+            ignore_frame = FrameNodeStatePositionChangedNotification()
+            ignore_frame.node_id = 80
+            ignore_frame.state = OperatingState.EXECUTING
+            ignore_frame.current_position = Position(position=Parameter.IGNORE)
+            ignore_frame.target = Position(position_percent=0)
+            ignore_frame.remaining_time = 3
+
+            await self.node_updater.process_frame(ignore_frame)
+
+            self.assertTrue(device.is_opening)
+            self.assertFalse(device.is_closing)
+            self.assertEqual(device.position, Position(position_percent=100))
+            self.assertEqual(device.target, Position(position_percent=0))
+
+        command_status = FrameCommandRunStatusNotification(
+            session_id=2,
+            status_id=1,
+            index_id=80,
+            node_parameter=0,
+            parameter_value=Parameter.UNKNOWN_VALUE,
+            run_status=RunStatus.EXECUTION_COMPLETED,
+            status_reply=StatusReply.COMMAND_OVERRULED,
+        )
+
+        await self.node_updater.process_frame(command_status)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+
+        done_frame = FrameNodeStatePositionChangedNotification()
+        done_frame.node_id = 80
+        done_frame.state = OperatingState.DONE
+        done_frame.current_position = Position(position_percent=0)
+        done_frame.target = Position(position_percent=0)
+        done_frame.remaining_time = 0
+
+        await self.node_updater.process_frame(done_frame)
+
+        self.assertFalse(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertEqual(device.position, Position(position_percent=0))
+        self.assertEqual(device.target, Position(position_percent=0))
+
+    async def test_gate_closing_live_sequence_keeps_direction_until_done(self) -> None:
+        """Live gate sequence should keep closing through IGNORE frames and stop on DONE."""
+        device = OpeningDevice(pyvlx=self.pyvlx, node_id=81, name="Test gate")
+        device.position = Position(position_percent=0)
+        device.target = Position(position_percent=0)
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[81] = device
+
+        start_frame = FrameNodeStatePositionChangedNotification()
+        start_frame.node_id = 81
+        start_frame.state = OperatingState.EXECUTING
+        start_frame.current_position = Position(position_percent=0)
+        start_frame.target = Position(position_percent=100)
+        start_frame.remaining_time = 1
+
+        await self.node_updater.process_frame(start_frame)
+
+        self.assertTrue(device.is_closing)
+        self.assertFalse(device.is_opening)
+        self.assertEqual(device.position, Position(position_percent=0))
+        self.assertEqual(device.target, Position(position_percent=100))
+
+        for _ in range(2):
+            ignore_frame = FrameNodeStatePositionChangedNotification()
+            ignore_frame.node_id = 81
+            ignore_frame.state = OperatingState.EXECUTING
+            ignore_frame.current_position = Position(position=Parameter.IGNORE)
+            ignore_frame.target = Position(position_percent=100)
+            ignore_frame.remaining_time = 3
+
+            await self.node_updater.process_frame(ignore_frame)
+
+            self.assertTrue(device.is_closing)
+            self.assertFalse(device.is_opening)
+            self.assertEqual(device.position, Position(position_percent=0))
+            self.assertEqual(device.target, Position(position_percent=100))
+
+        command_status = FrameCommandRunStatusNotification(
+            session_id=2,
+            status_id=1,
+            index_id=81,
+            node_parameter=0,
+            parameter_value=Parameter.UNKNOWN_VALUE,
+            run_status=RunStatus.EXECUTION_COMPLETED,
+            status_reply=StatusReply.COMMAND_OVERRULED,
+        )
+
+        await self.node_updater.process_frame(command_status)
+
+        self.assertTrue(device.is_closing)
+        self.assertFalse(device.is_opening)
+
+        done_frame = FrameNodeStatePositionChangedNotification()
+        done_frame.node_id = 81
+        done_frame.state = OperatingState.DONE
+        done_frame.current_position = Position(position_percent=100)
+        done_frame.target = Position(position_percent=100)
+        done_frame.remaining_time = 0
+
+        await self.node_updater.process_frame(done_frame)
+
+        self.assertFalse(device.is_closing)
+        self.assertFalse(device.is_opening)
+        self.assertEqual(device.position, Position(position_percent=100))
+        self.assertEqual(device.target, Position(position_percent=100))
+
     async def test_after_update_called_when_last_frame_state_changes(self) -> None:
         """Test that after_update() is called when last_frame_state changes."""
         device = OpeningDevice(

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1,5 +1,5 @@
 """Unit test for NodeUpdater."""
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines,too-many-public-methods
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -635,6 +635,66 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertFalse(device.is_closing)
         device.after_update.assert_awaited_once()
 
+    async def test_closing_derived_from_new_target_when_frame_position_is_ignore(self) -> None:
+        """A new higher target should indicate closing when the frame position is unavailable."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=78, name="Test gate"
+        )
+        device.position = Position(position_percent=100)
+        device.target = Position(position_percent=0)
+        device.is_opening = False
+        device.is_closing = False
+        device.last_frame_state = OperatingState.NOT_USED
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[78] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 78
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.IGNORE)
+        frame.target = Position(position_percent=100)
+        frame.remaining_time = 3
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_closing)
+        self.assertFalse(device.is_opening)
+        self.assertEqual(device.position, Position(position_percent=100))
+        self.assertEqual(device.target, Position(position_percent=100))
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
+        device.after_update.assert_awaited_once()
+
+    async def test_opening_derived_from_new_target_when_frame_position_is_unknown(self) -> None:
+        """A new lower target should indicate opening when the frame position is unavailable."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=79, name="Test gate"
+        )
+        device.position = Position(position_percent=0)
+        device.target = Position(position_percent=100)
+        device.is_opening = False
+        device.is_closing = False
+        device.last_frame_state = OperatingState.NOT_USED
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[79] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 79
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=0)
+        frame.remaining_time = 3
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertEqual(device.position, Position(position_percent=0))
+        self.assertEqual(device.target, Position(position_percent=0))
+        self.assertIsNotNone(device.state_received_at)
+        self.assertIsNotNone(device.estimated_completion)
+        device.after_update.assert_awaited_once()
+
     async def test_idle_device_stays_idle_when_frame_position_unknown(self) -> None:
         """An idle device must not be marked as moving when the frame position is unavailable."""
         device = OpeningDevice(


### PR DESCRIPTION
## Summary

Unfortunately, I'm still experiencing issues with my Somfy courtyard gate during a long-term test. The Somfy courtyard gate does not consistently report a usable current position. However, the error can be easily handled in pyvlx. This conservatively improves opening-device movement state handling when the KLF reports an unavailable current position while a concrete target changes.

## Root cause

For devices such as the courtyard gate, EXECUTING frames can report `current_position=IGNORE` or `UNKNOWN` while still carrying a meaningful target. The previous updater logic compared against the unavailable frame position and could miss the direction change, leaving `is_closing` or `is_opening` stale.

## Change

- Distinguish concrete frame positions from fallback comparison positions.
- For opening devices with unavailable current positions, derive movement direction from a concrete target change when the previous target is concrete.
- Keep updating the opening-device target during moving frames even when current position is unavailable.
- Add regression tests for closing from `IGNORE` and opening from `UNKNOWN`.

## Validation

- `.venv/bin/pytest -q test/node_updater_test.py` -> 39 passed
- `.venv/bin/pytest -q` -> 459 passed, 6 subtests passed
- Live checks with HA Velux disabled during pyvlx testing:
  - Courtyard gate open/close sequence reached final DONE with `position=100 %`, `target=100 %`, `is_opening=False`, `is_closing=False`.
  - Garage door, guest bathroom roof window, and office shutter regression checks completed cleanly with the local no-heartbeat live helper.
