### PR TITLE
[codex] Avoid async callbacks from Connection destructor

### DIFF
--- a/src/pyvlx/connection.py
+++ b/src/pyvlx/connection.py
@@ -96,7 +96,12 @@ class Connection:
         self.disconnect(notify_callbacks=False)
 
     def disconnect(self, notify_callbacks: bool = True) -> None:
-        """Disconnect connection."""
+        """Disconnect connection and notify callbacks if specified.
+
+        Running callbacks only makes sense if loop is still running,
+        so it it can be skipped, mostly for the case of destructor
+        being called during shutdown when loop is already closed.
+        """
         if self.transport is not None:
             self.transport.close()
             self.transport = None

--- a/src/pyvlx/connection.py
+++ b/src/pyvlx/connection.py
@@ -93,19 +93,26 @@ class Connection:
 
     def __del__(self) -> None:
         """Destruct connection."""
-        self.disconnect()
+        self.disconnect(notify_callbacks=False)
 
-    def disconnect(self) -> None:
+    def disconnect(self, notify_callbacks: bool = True) -> None:
         """Disconnect connection."""
         if self.transport is not None:
             self.transport.close()
             self.transport = None
         self.connected = False
         PYVLXLOG.debug("TCP transport closed.")
+        if not notify_callbacks:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            PYVLXLOG.debug("Skipping connection closed callbacks because no event loop is running.")
+            return
         for connection_closed_cb in self.connection_closed_cbs:
-            task = asyncio.create_task(connection_closed_cb())
+            task = loop.create_task(connection_closed_cb())
             self.tasks.add(task)
-            task.add_done_callback(self.tasks.remove)
+            task.add_done_callback(self.tasks.discard)
 
     async def connect(self) -> None:
         """Connect to gateway via SSL."""

--- a/test/connection_test.py
+++ b/test/connection_test.py
@@ -96,12 +96,12 @@ class TestConnection(IsolatedAsyncioTestCase):
         """Test __del__ closes the transport without scheduling async callbacks."""
         fake_transport = MagicMock(spec=asyncio.Transport)
         callback = MagicMock()
-        self.connection.transport = fake_transport
-        self.connection.connected = True
-        self.connection.register_connection_closed_cb(callback)
+        connection = Connection(config=self.config)
+        connection.transport = fake_transport
+        connection.connected = True
+        connection.register_connection_closed_cb(callback)
 
-        self.connection.__del__()
+        del connection
 
         fake_transport.close.assert_called_once()
-        self.assertFalse(self.connection.connected)
         callback.assert_not_called()

--- a/test/connection_test.py
+++ b/test/connection_test.py
@@ -59,3 +59,49 @@ class TestConnection(IsolatedAsyncioTestCase):
 
         self.assertTrue(self.connection.connected)
         self.assertEqual(self.connection.transport, fake_transport)
+
+    async def test_disconnect_schedules_connection_closed_callback(self) -> None:
+        """Test disconnect schedules connection closed callbacks when an event loop is running."""
+        fake_transport = MagicMock(spec=asyncio.Transport)
+        callback = AsyncMock()
+        self.connection.transport = fake_transport
+        self.connection.connected = True
+        self.connection.register_connection_closed_cb(callback)
+
+        self.connection.disconnect()
+
+        fake_transport.close.assert_called_once()
+        self.assertFalse(self.connection.connected)
+        tasks = list(self.connection.tasks)
+        self.assertEqual(len(tasks), 1)
+        await asyncio.gather(*tasks)
+        callback.assert_awaited_once()
+
+    def test_disconnect_without_running_loop_skips_connection_closed_callbacks(self) -> None:
+        """Test disconnect does not create callback coroutines without a running event loop."""
+        fake_transport = MagicMock(spec=asyncio.Transport)
+        callback = MagicMock()
+        self.connection.transport = fake_transport
+        self.connection.connected = True
+        self.connection.register_connection_closed_cb(callback)
+
+        with patch("pyvlx.connection.asyncio.get_running_loop", side_effect=RuntimeError):
+            self.connection.disconnect()
+
+        fake_transport.close.assert_called_once()
+        self.assertFalse(self.connection.connected)
+        callback.assert_not_called()
+
+    def test_destructor_closes_transport_without_connection_closed_callbacks(self) -> None:
+        """Test __del__ closes the transport without scheduling async callbacks."""
+        fake_transport = MagicMock(spec=asyncio.Transport)
+        callback = MagicMock()
+        self.connection.transport = fake_transport
+        self.connection.connected = True
+        self.connection.register_connection_closed_cb(callback)
+
+        self.connection.__del__()
+
+        fake_transport.close.assert_called_once()
+        self.assertFalse(self.connection.connected)
+        callback.assert_not_called()


### PR DESCRIPTION
## Summary

During a live test of my Somfy courtyard  gate, garage door, roller shutter, and Velux window, the following error occurred. The error was identified and resolved by Codex.
This fixes shutdown-time cleanup for `Connection.__del__` by avoiding async callback scheduling from the destructor and by making `disconnect()` safe when no event loop is running.

## Root cause

The destructor called `disconnect()`, which tried to schedule `connection_closed` callbacks. During interpreter shutdown, or after the event loop has already stopped, that can raise `RuntimeError: no running event loop` and leave an un-awaited coroutine warning.

## Change

- Add a `notify_callbacks` flag to `Connection.disconnect()`.
- Make `Connection.__del__` close the transport without scheduling async callbacks.
- Skip connection-closed callback scheduling when no event loop is running.
- Track callback tasks with `discard` in the done callback so cleanup is robust even if the task was already removed.
- Add regression tests for normal disconnect, no-running-loop disconnect, and destructor cleanup.

## Validation

- `.venv/bin/pytest -q test/connection_test.py` -> 6 passed
- `.venv/bin/pytest -q` -> 460 passed, 6 subtests passed
- Verified this addresses the shutdown traceback seen in the local live helper: `RuntimeError: no running event loop` / un-awaited `Node.after_update` coroutine warning.
