### PR TITLE
Fix status request main info parsing

### DIFF
--- a/src/pyvlx/api/frames/frame_status_request.py
+++ b/src/pyvlx/api/frames/frame_status_request.py
@@ -150,10 +150,10 @@ class FrameStatusRequestNotification(FrameBase):
         self.status_reply = StatusReply(payload[5])
         self.status_type = StatusType(payload[6])
         if self.status_type == StatusType.REQUEST_MAIN_INFO:
-            self.target_position = Parameter(payload[7:8])
-            self.current_position = Parameter(payload[9:10])
+            self.target_position = Parameter(payload[7:9])
+            self.current_position = Parameter(payload[9:11])
             self.remaining_time = payload[11] * 256 + payload[12]
-            self.last_master_execution_address = payload[13:16]
+            self.last_master_execution_address = payload[13:17]
             self.last_command_originator = payload[17]
         else:
             self.status_count = payload[7]

--- a/test/frame_status_request_test.py
+++ b/test/frame_status_request_test.py
@@ -6,6 +6,8 @@ from pyvlx.api.frames import (
     FrameStatusRequestConfirmation, FrameStatusRequestRequest)
 from pyvlx.api.frames.frame_status_request import (
     FrameStatusRequestNotification, StatusRequestStatus)
+from pyvlx.const import RunStatus, StatusReply, StatusType
+from pyvlx.parameter import Parameter
 
 
 class TestFrameStatusRequestRequest(unittest.TestCase):
@@ -72,6 +74,59 @@ class TestFrameStatusRequestNotification(unittest.TestCase):
         """Test parse FrameStatusRequestNotification from raw."""
         frame = frame_from_raw(self.EXAMPLE_FRAME_EMPTY)
         self.assertTrue(isinstance(frame, FrameStatusRequestNotification))
+
+    def test_request_main_info_from_raw(self) -> None:
+        """Test parse REQUEST_MAIN_INFO with 2-byte position fields."""
+        frame = FrameStatusRequestNotification()
+        frame.from_payload(bytes([
+            0x47, 0x11,  # session_id
+            0x02,  # status_id
+            0x07,  # node_id
+            RunStatus.EXECUTION_ACTIVE.value,
+            StatusReply.COMMAND_COMPLETED_OK.value,
+            StatusType.REQUEST_MAIN_INFO.value,
+            0xC4, 0x00,  # target_position
+            0xC3, 0xFF,  # current_position
+            0x12, 0x34,  # remaining_time
+            0x00, 0x65, 0x43, 0x21,  # last_master_execution_address
+            0x02,  # last_command_originator
+        ]))
+
+        self.assertEqual(frame.session_id, 0x4711)
+        self.assertEqual(frame.status_id, 0x02)
+        self.assertEqual(frame.node_id, 0x07)
+        self.assertEqual(frame.run_status, RunStatus.EXECUTION_ACTIVE)
+        self.assertEqual(frame.status_reply, StatusReply.COMMAND_COMPLETED_OK)
+        self.assertEqual(frame.status_type, StatusType.REQUEST_MAIN_INFO)
+        self.assertEqual(frame.target_position, Parameter(bytes([0xC4, 0x00])))
+        self.assertEqual(frame.current_position, Parameter(bytes([0xC3, 0xFF])))
+        self.assertEqual(frame.remaining_time, 0x1234)
+        self.assertEqual(frame.last_master_execution_address, bytes([0x00, 0x65, 0x43, 0x21]))
+        self.assertEqual(frame.last_command_originator, 0x02)
+
+    def test_request_main_info_roundtrip(self) -> None:
+        """Test REQUEST_MAIN_INFO can be serialized and parsed again."""
+        frame = FrameStatusRequestNotification()
+        frame.session_id = 0x4711
+        frame.status_id = 0x02
+        frame.node_id = 0x07
+        frame.run_status = RunStatus.EXECUTION_ACTIVE
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+        frame.status_type = StatusType.REQUEST_MAIN_INFO
+        frame.target_position = Parameter(bytes([0xC4, 0x00]))
+        frame.current_position = Parameter(bytes([0xC3, 0xFF]))
+        frame.remaining_time = 0x1234
+        frame.last_master_execution_address = bytes([0x00, 0x65, 0x43, 0x21])
+        frame.last_command_originator = 0x02
+
+        restored = FrameStatusRequestNotification()
+        restored.from_payload(frame.get_payload())
+
+        self.assertEqual(restored.target_position, frame.target_position)
+        self.assertEqual(restored.current_position, frame.current_position)
+        self.assertEqual(restored.remaining_time, frame.remaining_time)
+        self.assertEqual(restored.last_master_execution_address, frame.last_master_execution_address)
+        self.assertEqual(restored.last_command_originator, frame.last_command_originator)
 
     def test_str(self) -> None:
         """Test string representation of FrameStatusRequestNotification."""


### PR DESCRIPTION
## Summary

Fix parsing of `GW_STATUS_REQUEST_NTF` notifications with `StatusType.REQUEST_MAIN_INFO`.

This fixes a parser bug that could produce wrong target/current position values for real KLF200 status request notifications. `TargetPosition` and `CurrentPosition` are 16-bit functional parameter values, but pyvlx previously sliced only one byte for each field.

## Details

For `REQUEST_MAIN_INFO`, the payload layout is:

- bytes 7-8: `TargetPosition`
- bytes 9-10: `CurrentPosition`
- bytes 11-12: `RemainingTime`
- bytes 13-16: `LastMasterExecutionAddress`
- byte 17: `LastCommandOriginator`

The parser now reads the full 2-byte position fields and the full 4-byte execution address.

## Tests

Added regression coverage for:

- parsing `REQUEST_MAIN_INFO` from raw payload with non-trivial 2-byte values
- roundtripping `REQUEST_MAIN_INFO` through `get_payload()` and `from_payload()`

Validation:

- `.venv/bin/python -m pytest test/frame_status_request_test.py`
- `.venv/bin/python -m pytest`

Fixes #675