### PR TITLE
Fix status request node id parsing

### DIFF
--- a/src/pyvlx/api/frames/frame_status_request.py
+++ b/src/pyvlx/api/frames/frame_status_request.py
@@ -43,7 +43,7 @@ class FrameStatusRequestRequest(FrameBase):
             raise PyVLXException("command_send_request_wrong_node_length")
         self.node_ids = []
         for i in range(len_node_ids):
-            self.node_ids.append(payload[3] + i)
+            self.node_ids.append(payload[3 + i])
 
         self.status_type = StatusType(payload[23])
         self.fpi1 = payload[24]

--- a/test/frame_status_request_test.py
+++ b/test/frame_status_request_test.py
@@ -24,6 +24,29 @@ class TestFrameStatusRequestRequest(unittest.TestCase):
         frame = frame_from_raw(self.EXAMPLE_FRAME)
         self.assertTrue(isinstance(frame, FrameStatusRequestRequest))
 
+    def test_from_raw_with_non_consecutive_node_ids(self) -> None:
+        """Test parse FrameStatusRequestRequest preserves encoded node IDs."""
+        raw = b"\x00\x1d\x03\x05\x00\xab\x02\x2a\x57" + bytes(18) + b"\x01\xfe\x000"
+
+        frame = frame_from_raw(raw)
+
+        self.assertTrue(isinstance(frame, FrameStatusRequestRequest))
+        assert isinstance(frame, FrameStatusRequestRequest)
+        self.assertEqual(frame.node_ids, [42, 87])
+
+    def test_request_with_non_consecutive_node_ids_roundtrip(self) -> None:
+        """Test FrameStatusRequestRequest survives a payload roundtrip with non-consecutive IDs."""
+        frame = FrameStatusRequestRequest(node_ids=[42, 87, 7], session_id=0x00ab)
+        restored = FrameStatusRequestRequest()
+
+        restored.from_payload(frame.get_payload())
+
+        self.assertEqual(restored.session_id, frame.session_id)
+        self.assertEqual(restored.node_ids, frame.node_ids)
+        self.assertEqual(restored.status_type, frame.status_type)
+        self.assertEqual(restored.fpi1, frame.fpi1)
+        self.assertEqual(restored.fpi2, frame.fpi2)
+
     def test_str(self) -> None:
         """Test string representation of FrameStatusRequestRequest."""
         frame = FrameStatusRequestRequest(node_ids=[1, 2], session_id=0xAB)


### PR DESCRIPTION
## Summary

Fix parsing of node IDs in `FrameStatusRequestRequest.from_payload()`.

The parser previously read the first node ID and incremented it for each entry, which only worked for strictly consecutive node IDs. Real payloads can contain arbitrary node IDs, for example `[42, 87]`.

## Details

`get_payload()` already serializes each node ID into the IndexArray correctly. `from_payload()` now mirrors that behavior and reads each node ID from its encoded byte.

## Tests

Added regression coverage for:

- parsing a raw `GW_STATUS_REQUEST_REQ` payload with non-consecutive node IDs
- roundtripping non-consecutive node IDs through `get_payload()` and `from_payload()`

Fixes #677
