### PR TITLE
Fix/clear motion state from status request

### DIFF
--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -45,6 +45,16 @@ class NodeUpdater:
         """Return True when a position can be used for movement comparisons."""
         return position.position <= Parameter.MAX
 
+    @staticmethod
+    def _clear_opening_device_motion(node: OpeningDevice) -> bool:
+        """Clear stale motion state for a completed opening device movement."""
+        node_changed = False
+        node_changed |= _set_node_property(node, "is_opening", False)
+        node_changed |= _set_node_property(node, "is_closing", False)
+        node.state_received_at = None
+        node.estimated_completion = None
+        return node_changed
+
     async def process_frame_status_request_notification(
         self, frame: FrameStatusRequestNotification
     ) -> None:
@@ -58,16 +68,21 @@ class NodeUpdater:
         node_changed |= _set_node_property(node, "last_frame_status_reply", new_value=frame.status_reply)
         node_changed |= _set_node_property(node, "last_frame_run_status", new_value=frame.run_status)
 
+        status_position: Position | None = None
+        status_position_is_concrete = False
+        if NodeParameter(0) in frame.parameter_data:  # MP
+            status_position = Position(frame.parameter_data[NodeParameter(0)])
+            status_position_is_concrete = self._is_concrete_position(status_position)
+
         if isinstance(node, Blind):
             if (
                 # MP and FP3 are needed in frame, so check if they are present before accessing them
-                NodeParameter(0) in frame.parameter_data  # MP
+                status_position is not None
                 and NodeParameter(3) in frame.parameter_data  # FP3
             ):
-                position = Position(frame.parameter_data[NodeParameter(0)])
                 orientation = Position(frame.parameter_data[NodeParameter(3)])
-                if position.position <= Parameter.MAX:
-                    node_changed |= _set_node_property(node, "position", position)
+                if status_position_is_concrete:
+                    node_changed |= _set_node_property(node, "position", status_position)
                 if orientation.position <= Parameter.MAX:
                     node_changed |= _set_node_property(node, "orientation", orientation)
 
@@ -75,30 +90,29 @@ class NodeUpdater:
             if (
                 # MP, FP1 and FP2 are needed in frame,
                 # so check if they are present before accessing them
-                NodeParameter(0) in frame.parameter_data  # MP
+                status_position is not None
                 and NodeParameter(1) in frame.parameter_data  # FP1
                 and NodeParameter(2) in frame.parameter_data  # FP2
             ):
-                position = Position(frame.parameter_data[NodeParameter(0)])
                 position_upper_curtain = Position(frame.parameter_data[NodeParameter(1)])
                 position_lower_curtain = Position(frame.parameter_data[NodeParameter(2)])
-                if position.position <= Parameter.MAX:
-                    node_changed |= _set_node_property(node, "position", position)
+                if status_position_is_concrete:
+                    node_changed |= _set_node_property(node, "position", status_position)
                 if position_upper_curtain.position <= Parameter.MAX:
                     node_changed |= _set_node_property(node, "position_upper_curtain", position_upper_curtain)
                 if position_lower_curtain.position <= Parameter.MAX:
                     node_changed |= _set_node_property(node, "position_lower_curtain", position_lower_curtain)
 
         elif isinstance(node, OpeningDevice):
-            if NodeParameter(0) in frame.parameter_data:  # MP
-                position = Position(frame.parameter_data[NodeParameter(0)])
-                if self._is_concrete_position(position):
-                    node_changed |= _set_node_property(node, "position", position)
-                    if frame.run_status == RunStatus.EXECUTION_COMPLETED:
-                        node_changed |= _set_node_property(node, "is_opening", False)
-                        node_changed |= _set_node_property(node, "is_closing", False)
-                        node.state_received_at = None
-                        node.estimated_completion = None
+            if status_position_is_concrete:
+                node_changed |= _set_node_property(node, "position", status_position)
+
+        if (
+            isinstance(node, OpeningDevice)
+            and status_position_is_concrete
+            and frame.run_status == RunStatus.EXECUTION_COMPLETED
+        ):
+            node_changed |= self._clear_opening_device_motion(node)
 
         if node_changed:
             await node.after_update()

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -6,7 +6,7 @@ from .api.frames import (
     FrameBase, FrameCommandRunStatusNotification,
     FrameGetAllNodesInformationNotification,
     FrameNodeStatePositionChangedNotification, FrameStatusRequestNotification)
-from .const import NodeParameter, OperatingState
+from .const import NodeParameter, OperatingState, RunStatus
 from .dimmable_device import DimmableDevice
 from .log import PYVLXLOG
 from .node import Node
@@ -94,6 +94,13 @@ class NodeUpdater:
                 position = Position(frame.parameter_data[NodeParameter(0)])
                 if self._is_concrete_position(position):
                     node_changed |= _set_node_property(node, "position", position)
+                    if frame.run_status == RunStatus.EXECUTION_COMPLETED:
+                        if node.is_opening:
+                            node_changed |= _set_node_property(node, "is_opening", False)
+                        if node.is_closing:
+                            node_changed |= _set_node_property(node, "is_closing", False)
+                        node.state_received_at = None
+                        node.estimated_completion = None
 
         if node_changed:
             await node.after_update()

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -95,10 +95,8 @@ class NodeUpdater:
                 if self._is_concrete_position(position):
                     node_changed |= _set_node_property(node, "position", position)
                     if frame.run_status == RunStatus.EXECUTION_COMPLETED:
-                        if node.is_opening:
-                            node_changed |= _set_node_property(node, "is_opening", False)
-                        if node.is_closing:
-                            node_changed |= _set_node_property(node, "is_closing", False)
+                        node_changed |= _set_node_property(node, "is_opening", False)
+                        node_changed |= _set_node_property(node, "is_closing", False)
                         node.state_received_at = None
                         node.estimated_completion = None
 

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -360,6 +360,42 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(blind.orientation, Position(position_percent=30))
         blind.after_update.assert_awaited_once()
 
+    async def test_blind_motion_stops_from_completed_status_request(self) -> None:
+        """Test that a completed status request clears a stale Blind motion state."""
+        blind = Blind(
+            pyvlx=self.pyvlx, node_id=1, name="Test blind", serial_number=None
+        )
+        blind.position = Position(position_percent=100)
+        blind.orientation = Position(position_percent=50)
+        blind.target = Position(position_percent=0)
+        blind.is_opening = True
+        blind.state_received_at = datetime.datetime.now()
+        blind.estimated_completion = (
+            blind.state_received_at + datetime.timedelta(seconds=17)
+        )
+        blind.last_frame_status_reply = StatusReply.COMMAND_COMPLETED_OK
+        blind.last_frame_run_status = RunStatus.EXECUTION_ACTIVE
+        blind.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[1] = blind
+
+        frame = FrameStatusRequestNotification()
+        frame.node_id = 1
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.parameter_data = {
+            NodeParameter(0): Parameter(Position(position_percent=0).raw),
+            NodeParameter(3): Parameter(Position(position_percent=50).raw),
+        }
+
+        await self.node_updater.process_frame_status_request_notification(frame)
+
+        self.assertEqual(blind.position, Position(position_percent=0))
+        self.assertFalse(blind.is_opening)
+        self.assertFalse(blind.is_closing)
+        self.assertIsNone(blind.state_received_at)
+        self.assertIsNone(blind.estimated_completion)
+        blind.after_update.assert_awaited_once()
+
     async def test_dual_roller_shutter_position_changed_triggers_after_update(self) -> None:
         """Test that a DualRollerShutter frame with changed positions triggers after_update() once."""
         shutter = DualRollerShutter(
@@ -387,6 +423,46 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(shutter.position, Position(position_percent=30))
         self.assertEqual(shutter.position_upper_curtain, Position(position_percent=40))
         self.assertEqual(shutter.position_lower_curtain, Position(position_percent=60))
+        shutter.after_update.assert_awaited_once()
+
+    async def test_dual_roller_shutter_motion_stops_from_completed_status_request(self) -> None:
+        """Test that a completed status request clears a stale DualRollerShutter motion state."""
+        shutter = DualRollerShutter(
+            pyvlx=self.pyvlx, node_id=2, name="Test shutter", serial_number=None
+        )
+        shutter.position = Position(position_percent=100)
+        shutter.position_upper_curtain = Position(position_percent=100)
+        shutter.position_lower_curtain = Position(position_percent=100)
+        shutter.target = Position(position_percent=0)
+        shutter.is_opening = True
+        shutter.state_received_at = datetime.datetime.now()
+        shutter.estimated_completion = (
+            shutter.state_received_at + datetime.timedelta(seconds=17)
+        )
+        shutter.last_frame_status_reply = StatusReply.COMMAND_COMPLETED_OK
+        shutter.last_frame_run_status = RunStatus.EXECUTION_ACTIVE
+        shutter.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[2] = shutter
+
+        frame = FrameStatusRequestNotification()
+        frame.node_id = 2
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.parameter_data = {
+            NodeParameter(0): Parameter(Position(position_percent=0).raw),
+            NodeParameter(1): Parameter(Position(position_percent=25).raw),
+            NodeParameter(2): Parameter(Position(position_percent=75).raw),
+        }
+
+        await self.node_updater.process_frame_status_request_notification(frame)
+
+        self.assertEqual(shutter.position, Position(position_percent=0))
+        self.assertEqual(shutter.position_upper_curtain, Position(position_percent=25))
+        self.assertEqual(shutter.position_lower_curtain, Position(position_percent=75))
+        self.assertFalse(shutter.is_opening)
+        self.assertFalse(shutter.is_closing)
+        self.assertIsNone(shutter.state_received_at)
+        self.assertIsNone(shutter.estimated_completion)
         shutter.after_update.assert_awaited_once()
 
     async def test_dual_roller_shutter_no_change_skips_after_update(self) -> None:

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1,5 +1,6 @@
 """Unit test for NodeUpdater."""
 # pylint: disable=too-many-lines,too-many-public-methods
+import datetime
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 
@@ -543,6 +544,108 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         await self.node_updater.process_frame_status_request_notification(frame)
 
         self.assertEqual(roller_shutter.position, Position(position_percent=75))
+        roller_shutter.after_update.assert_awaited_once()
+
+    async def test_roller_shutter_motion_stops_from_completed_status_request(self) -> None:
+        """Test that a completed status request clears a stale RollerShutter motion state."""
+        roller_shutter = RollerShutter(
+            pyvlx=self.pyvlx, node_id=6, name="Test roller shutter", serial_number=None
+        )
+        roller_shutter.position = Position(position_percent=100)
+        roller_shutter.target = Position(position_percent=0)
+        roller_shutter.is_opening = True
+        roller_shutter.state_received_at = datetime.datetime.now()
+        roller_shutter.estimated_completion = (
+            roller_shutter.state_received_at + datetime.timedelta(seconds=17)
+        )
+        roller_shutter.last_frame_status_reply = StatusReply.COMMAND_COMPLETED_OK
+        roller_shutter.last_frame_run_status = RunStatus.EXECUTION_ACTIVE
+        roller_shutter.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[6] = roller_shutter
+
+        frame = FrameStatusRequestNotification()
+        frame.node_id = 6
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.parameter_data = {
+            NodeParameter(0): Parameter(Position(position_percent=0).raw),
+        }
+
+        await self.node_updater.process_frame_status_request_notification(frame)
+
+        self.assertEqual(roller_shutter.position, Position(position_percent=0))
+        self.assertFalse(roller_shutter.is_opening)
+        self.assertFalse(roller_shutter.is_closing)
+        self.assertIsNone(roller_shutter.state_received_at)
+        self.assertIsNone(roller_shutter.estimated_completion)
+        roller_shutter.after_update.assert_awaited_once()
+
+    async def test_roller_shutter_closing_stops_from_completed_status_request(self) -> None:
+        """Test that a completed status request clears a stale RollerShutter closing state."""
+        roller_shutter = RollerShutter(
+            pyvlx=self.pyvlx, node_id=6, name="Test roller shutter", serial_number=None
+        )
+        roller_shutter.position = Position(position_percent=0)
+        roller_shutter.target = Position(position_percent=100)
+        roller_shutter.is_closing = True
+        roller_shutter.state_received_at = datetime.datetime.now()
+        roller_shutter.estimated_completion = (
+            roller_shutter.state_received_at + datetime.timedelta(seconds=17)
+        )
+        roller_shutter.last_frame_status_reply = StatusReply.COMMAND_COMPLETED_OK
+        roller_shutter.last_frame_run_status = RunStatus.EXECUTION_ACTIVE
+        roller_shutter.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[6] = roller_shutter
+
+        frame = FrameStatusRequestNotification()
+        frame.node_id = 6
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.parameter_data = {
+            NodeParameter(0): Parameter(Position(position_percent=100).raw),
+        }
+
+        await self.node_updater.process_frame_status_request_notification(frame)
+
+        self.assertEqual(roller_shutter.position, Position(position_percent=100))
+        self.assertFalse(roller_shutter.is_opening)
+        self.assertFalse(roller_shutter.is_closing)
+        self.assertIsNone(roller_shutter.state_received_at)
+        self.assertIsNone(roller_shutter.estimated_completion)
+        roller_shutter.after_update.assert_awaited_once()
+
+    async def test_roller_shutter_active_status_request_keeps_motion_state(self) -> None:
+        """Test that an active status request does not clear RollerShutter motion state."""
+        roller_shutter = RollerShutter(
+            pyvlx=self.pyvlx, node_id=6, name="Test roller shutter", serial_number=None
+        )
+        roller_shutter.position = Position(position_percent=100)
+        roller_shutter.target = Position(position_percent=0)
+        roller_shutter.is_opening = True
+        roller_shutter.state_received_at = datetime.datetime.now()
+        roller_shutter.estimated_completion = (
+            roller_shutter.state_received_at + datetime.timedelta(seconds=17)
+        )
+        roller_shutter.last_frame_status_reply = StatusReply.COMMAND_COMPLETED_OK
+        roller_shutter.last_frame_run_status = RunStatus.EXECUTION_ACTIVE
+        roller_shutter.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[6] = roller_shutter
+
+        frame = FrameStatusRequestNotification()
+        frame.node_id = 6
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+        frame.run_status = RunStatus.EXECUTION_ACTIVE
+        frame.parameter_data = {
+            NodeParameter(0): Parameter(Position(position_percent=50).raw),
+        }
+
+        await self.node_updater.process_frame_status_request_notification(frame)
+
+        self.assertEqual(roller_shutter.position, Position(position_percent=50))
+        self.assertTrue(roller_shutter.is_opening)
+        self.assertFalse(roller_shutter.is_closing)
+        self.assertIsNotNone(roller_shutter.state_received_at)
+        self.assertIsNotNone(roller_shutter.estimated_completion)
         roller_shutter.after_update.assert_awaited_once()
 
     async def test_opening_device_ignores_unavailable_status_request_position(self) -> None:


### PR DESCRIPTION
Fixes #682

Depends on #680 

This PR builds on the status request OpeningDevice position update from #680. Please review/merge that PR first; after it lands, this branch can be rebased onto master so the diff only contains the motion-state cleanup.

During live testing with a Somfy roller shutter, the KLF200 sent a complete movement sequence for opening and closing. The final successful sequence included:

```
GW_COMMAND_RUN_STATUS_NTF: run_status=EXECUTION_COMPLETED
GW_SESSION_FINISHED_NTF
GW_NODE_STATE_POSITION_CHANGED_NTF: current_position=0 %, target=0 %, state=DONE
```

pyvlx currently clears `is_opening` / `is_closing` when the final `GW_NODE_STATE_POSITION_CHANGED_NTF` is processed. If that final DONE state frame is missed or delayed, Home Assistant can keep showing the cover as `opening` / `closing` even though the physical movement has already completed.

The heartbeat/status request path can later report the concrete final MP position together with `run_status=EXECUTION_COMPLETED`. With the preceding status request position update, pyvlx already uses that MP value to recover the position. This PR also clears stale motion state from that completed status request.

Changes:

- When a generic `OpeningDevice` receives a concrete `NodeParameter(0)` / MP value from `FrameStatusRequestNotification`
- and the notification has `run_status == RunStatus.EXECUTION_COMPLETED`
- clear `is_opening` / `is_closing`
- clear `state_received_at` / `estimated_completion`
- keep motion state unchanged for `RunStatus.EXECUTION_ACTIVE`
