### PR TITLE
Fix dynamic version for github tag builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.client_payload.tag || github.event.release.tag_name }}
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Set up Python 
       uses: actions/setup-python@v6


### PR DESCRIPTION
This was broken since https://github.com/Julius2342/pyvlx/pull/582, which started determining the version from the latest github version tag. This worked for the actual release build but not for tag builds, because the checkout did not have any tags. 