### PR TITLE
Clear stuck motion state for IGNORE-position devices and skip heartbeat polling during travel

### DIFF
--- a/src/pyvlx/heartbeat.py
+++ b/src/pyvlx/heartbeat.py
@@ -82,14 +82,15 @@ class Heartbeat:
         # If nodes contain Blind or DualRollerShutter device, refresh orientation or upper/lower curtain positions because House Monitoring
         # delivers wrong values for FP1, FP2 and FP3 parameter
         for node in self.pyvlx.nodes:
-            # A StatusRequest issued to a node mid-travel makes the KLF200
-            # report the active ActivateScene/SetPosition command as
-            # COMMAND_OVERRULED with run_status = EXECUTION_COMPLETED, which
-            # downstream consumers cannot distinguish from a genuine limit-
-            # switch completion. Worse, on some actuators (gates, garage
-            # doors) the gateway actually halts the motion. Skip polling
-            # nodes that are currently moving; House Monitoring delivers the
-            # in-flight position updates anyway.
+            # A StatusRequest issued to a node mid-travel can make the
+            # KLF200 emit a run_status = EXECUTION_COMPLETED notification
+            # for the currently active command — sometimes with
+            # status_reply = COMMAND_OVERRULED. Downstream consumers
+            # cannot distinguish that from a genuine end-of-travel
+            # completion, and on some actuators (gates, garage doors) the
+            # gateway can additionally interrupt the motion. Skip polling
+            # nodes that are currently moving; House Monitoring delivers
+            # the in-flight position updates anyway.
             if isinstance(node, OpeningDevice) and (
                 node.is_opening or node.is_closing
             ):

--- a/src/pyvlx/heartbeat.py
+++ b/src/pyvlx/heartbeat.py
@@ -7,7 +7,7 @@ from .api import GetState
 from .api.status_request import StatusRequest
 from .exception import PyVLXException
 from .log import PYVLXLOG
-from .opening_device import Blind, DualRollerShutter
+from .opening_device import Blind, DualRollerShutter, OpeningDevice
 
 if TYPE_CHECKING:
     from pyvlx import PyVLX
@@ -82,6 +82,22 @@ class Heartbeat:
         # If nodes contain Blind or DualRollerShutter device, refresh orientation or upper/lower curtain positions because House Monitoring
         # delivers wrong values for FP1, FP2 and FP3 parameter
         for node in self.pyvlx.nodes:
+            # A StatusRequest issued to a node mid-travel makes the KLF200
+            # report the active ActivateScene/SetPosition command as
+            # COMMAND_OVERRULED with run_status = EXECUTION_COMPLETED, which
+            # downstream consumers cannot distinguish from a genuine limit-
+            # switch completion. Worse, on some actuators (gates, garage
+            # doors) the gateway actually halts the motion. Skip polling
+            # nodes that are currently moving; House Monitoring delivers the
+            # in-flight position updates anyway.
+            if isinstance(node, OpeningDevice) and (
+                node.is_opening or node.is_closing
+            ):
+                PYVLXLOG.debug(
+                    "Heartbeat: skipping node %s while it is in motion",
+                    node.name,
+                )
+                continue
             if isinstance(node, (Blind, DualRollerShutter)) or self.load_all_states:
                 status_request = StatusRequest(self.pyvlx, node.node_id)
                 await status_request.do_api_call()

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -6,7 +6,7 @@ from .api.frames import (
     FrameBase, FrameCommandRunStatusNotification,
     FrameGetAllNodesInformationNotification,
     FrameNodeStatePositionChangedNotification, FrameStatusRequestNotification)
-from .const import NodeParameter, OperatingState, RunStatus
+from .const import NodeParameter, OperatingState, RunStatus, StatusReply
 from .dimmable_device import DimmableDevice
 from .log import PYVLXLOG
 from .node import Node
@@ -340,18 +340,43 @@ class NodeUpdater:
             and (node.is_opening or node.is_closing)
         ):
             # EXECUTION_COMPLETED is the gateway's signal that the active
-            # command run has finished for this node. Treat it as
-            # authoritative for our motion tracking and sync the cached
-            # position to the target so consumers don't briefly see a stale
-            # pre-move position when the IGNORE-mode position frames never
-            # updated it during travel. EXECUTION_FAILED leaves the position
-            # untouched because the device did not necessarily reach its
-            # target.
+            # command run has finished for this node and is therefore
+            # authoritative for our motion tracking.
+            #
+            # Only on a clean completion (COMMAND_COMPLETED_OK) can we
+            # additionally assume the device actually reached its target;
+            # in that case we sync the cached position so consumers don't
+            # briefly see a stale pre-move value when the IGNORE-mode
+            # position frames never updated it during travel. Other
+            # status_reply values mean the run was pre-empted before
+            # reaching the target (e.g. COMMAND_OVERRULED by a new
+            # command), so the position must stay at whatever the latest
+            # state frame established. EXECUTION_FAILED is similar — the
+            # device did not reach the target.
+            #
+            # Sync source preference: the CRSN payload itself carries the
+            # final main-parameter value, which is more up-to-date than
+            # the cached node.target if the matching state frame has not
+            # arrived yet. Fall back to node.target only when the payload
+            # is not a concrete MP value.
             if (
                 frame.run_status == RunStatus.EXECUTION_COMPLETED
-                and self._is_concrete_position(node.target)
+                and frame.status_reply == StatusReply.COMMAND_COMPLETED_OK
             ):
-                node_changed |= _set_node_property(node, "position", node.target)
+                synced_position: Position | None = None
+                if (
+                    frame.node_parameter == NodeParameter.MP.value
+                    and frame.parameter_value is not None
+                ):
+                    candidate = Position(position=frame.parameter_value)
+                    if self._is_concrete_position(candidate):
+                        synced_position = candidate
+                if synced_position is None and self._is_concrete_position(node.target):
+                    synced_position = node.target
+                if synced_position is not None:
+                    node_changed |= _set_node_property(
+                        node, "position", synced_position
+                    )
             node_changed |= self._clear_opening_device_motion(node)
             PYVLXLOG.debug(
                 "%s motion cleared after command run finished (%s)",

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -339,6 +339,18 @@ class NodeUpdater:
             and frame.run_status in (RunStatus.EXECUTION_COMPLETED, RunStatus.EXECUTION_FAILED)
             and (node.is_opening or node.is_closing)
         ):
+            # On EXECUTION_COMPLETED we can assume the device reached its target
+            # (the KLF200 ends gate/garage runs with COMMAND_OVERRULED at the
+            # limit switch, which is a physical completion proof). Sync the
+            # cached position to the target so consumers don't briefly see a
+            # stale pre-move position when the IGNORE-mode position frames
+            # never updated it. EXECUTION_FAILED leaves the position untouched
+            # because the device did not reach its target.
+            if (
+                frame.run_status == RunStatus.EXECUTION_COMPLETED
+                and self._is_concrete_position(node.target)
+            ):
+                node_changed |= _set_node_property(node, "position", node.target)
             node_changed |= self._clear_opening_device_motion(node)
             PYVLXLOG.debug(
                 "%s motion cleared after command run finished (%s)",

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -222,9 +222,14 @@ class NodeUpdater:
                 # the device as executing (observed on garage doors after the limit
                 # switch trips: a final EXECUTING frame can arrive with stale
                 # remaining_time > 0, which would otherwise trap is_closing/is_opening).
+                # Use the semantic Position.closed/open accessors so devices that report
+                # closed-with-tolerance (e.g. Velux SML, which does not necessarily hit
+                # exactly Parameter.MAX) still match the escape.
                 self._is_concrete_position(node.position)
-                and node.position.position == target.position
-                and (target.closed or target.open)
+                and (
+                    (target.closed and node.position.closed)
+                    or (target.open and node.position.open)
+                )
             )
         ):
             node.state_received_at = datetime.datetime.now()
@@ -364,17 +369,9 @@ class NodeUpdater:
                 and frame.status_reply == StatusReply.COMMAND_COMPLETED_OK
             ):
                 synced_position: Position | None = None
-                # Validate parameter_value via Parameter.is_valid_int before
-                # constructing a Position; otherwise an unexpected raw value
-                # from the gateway would raise PyVLXException out of the
-                # frame handler. Known special values (UNKNOWN_VALUE, IGNORE,
-                # CURRENT, TARGET, DUAL_SHUTTER_CURTAINS) pass validation but
-                # are filtered out by _is_concrete_position below and fall
-                # through to the node.target fallback.
                 if (
                     frame.node_parameter == NodeParameter.MP.value
                     and frame.parameter_value is not None
-                    and Parameter.is_valid_int(frame.parameter_value)
                 ):
                     candidate = Position(position=frame.parameter_value)
                     if self._is_concrete_position(candidate):

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -364,9 +364,17 @@ class NodeUpdater:
                 and frame.status_reply == StatusReply.COMMAND_COMPLETED_OK
             ):
                 synced_position: Position | None = None
+                # Validate parameter_value via Parameter.is_valid_int before
+                # constructing a Position; otherwise an unexpected raw value
+                # from the gateway would raise PyVLXException out of the
+                # frame handler. Known special values (UNKNOWN_VALUE, IGNORE,
+                # CURRENT, TARGET, DUAL_SHUTTER_CURTAINS) pass validation but
+                # are filtered out by _is_concrete_position below and fall
+                # through to the node.target fallback.
                 if (
                     frame.node_parameter == NodeParameter.MP.value
                     and frame.parameter_value is not None
+                    and Parameter.is_valid_int(frame.parameter_value)
                 ):
                     candidate = Position(position=frame.parameter_value)
                     if self._is_concrete_position(candidate):

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -339,13 +339,14 @@ class NodeUpdater:
             and frame.run_status in (RunStatus.EXECUTION_COMPLETED, RunStatus.EXECUTION_FAILED)
             and (node.is_opening or node.is_closing)
         ):
-            # On EXECUTION_COMPLETED we can assume the device reached its target
-            # (the KLF200 ends gate/garage runs with COMMAND_OVERRULED at the
-            # limit switch, which is a physical completion proof). Sync the
-            # cached position to the target so consumers don't briefly see a
-            # stale pre-move position when the IGNORE-mode position frames
-            # never updated it. EXECUTION_FAILED leaves the position untouched
-            # because the device did not reach its target.
+            # EXECUTION_COMPLETED is the gateway's signal that the active
+            # command run has finished for this node. Treat it as
+            # authoritative for our motion tracking and sync the cached
+            # position to the target so consumers don't briefly see a stale
+            # pre-move position when the IGNORE-mode position frames never
+            # updated it during travel. EXECUTION_FAILED leaves the position
+            # untouched because the device did not necessarily reach its
+            # target.
             if (
                 frame.run_status == RunStatus.EXECUTION_COMPLETED
                 and self._is_concrete_position(node.target)

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -212,7 +212,21 @@ class NodeUpdater:
                 node.estimated_completion.strftime("%Y-%m-%d %H:%M:%S"),
             )
 
-        elif frame_indicates_motion and target_is_concrete and (node.is_opening or node.is_closing):
+        elif (
+            frame_indicates_motion
+            and target_is_concrete
+            and (node.is_opening or node.is_closing)
+            and not (
+                # Cached position already reached an open/closed extreme that matches the
+                # target: treat the motion as complete even when the gateway still flags
+                # the device as executing (observed on garage doors after the limit
+                # switch trips: a final EXECUTING frame can arrive with stale
+                # remaining_time > 0, which would otherwise trap is_closing/is_opening).
+                self._is_concrete_position(node.position)
+                and node.position.position == target.position
+                and (target.closed or target.open)
+            )
+        ):
             node.state_received_at = datetime.datetime.now()
             node.estimated_completion = (
                 node.state_received_at

--- a/src/pyvlx/node_updater.py
+++ b/src/pyvlx/node_updater.py
@@ -328,6 +328,24 @@ class NodeUpdater:
         node_changed |= _set_node_property(node, "last_frame_status_reply", new_value=frame.status_reply)
         node_changed |= _set_node_property(node, "last_frame_run_status", new_value=frame.run_status)
 
+        # Gates and garage doors frequently keep current_position = IGNORE for the
+        # entire travel and only signal completion via this command-run-status
+        # frame (run_status = COMPLETED/FAILED). Without clearing motion here,
+        # is_opening/is_closing would only fall back to False on the next polled
+        # status sweep, leaving the entity stuck in opening/closing for up to a
+        # full heartbeat period.
+        if (
+            isinstance(node, OpeningDevice)
+            and frame.run_status in (RunStatus.EXECUTION_COMPLETED, RunStatus.EXECUTION_FAILED)
+            and (node.is_opening or node.is_closing)
+        ):
+            node_changed |= self._clear_opening_device_motion(node)
+            PYVLXLOG.debug(
+                "%s motion cleared after command run finished (%s)",
+                node.name,
+                frame.run_status.name,
+            )
+
         if node_changed:
             await node.after_update()
 

--- a/test/heartbeat_test.py
+++ b/test/heartbeat_test.py
@@ -198,10 +198,10 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
     ) -> None:
         """Skip status polling for any OpeningDevice currently in motion.
 
-        Polling a node mid-travel makes the KLF200 overrule the active
-        command and can halt the device on some actuators, so the
-        heartbeat must skip any OpeningDevice with is_opening or
-        is_closing set.
+        Polling a node mid-travel can cause the KLF200 to report the
+        active command as completed prematurely and, on some actuators,
+        interrupt the motion. The heartbeat must therefore skip any
+        OpeningDevice with is_opening or is_closing set.
         """
         moving_gate = Gate(self.pyvlx, node_id=16, name="Gate", serial_number=None)
         moving_gate.is_closing = True

--- a/test/heartbeat_test.py
+++ b/test/heartbeat_test.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 from pyvlx import PyVLX
 from pyvlx.exception import PyVLXException
 from pyvlx.heartbeat import Heartbeat
-from pyvlx.opening_device import Blind
+from pyvlx.opening_device import Blind, Gate
 
 
 class TestHeartbeat(IsolatedAsyncioTestCase):
@@ -186,3 +186,42 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
         status_request_1.do_api_call.assert_awaited_once()
         status_request_2.do_api_call.assert_awaited_once()
         self.assertEqual(sleep_mock.await_count, 2)
+
+    @patch("pyvlx.heartbeat.asyncio.sleep", new_callable=AsyncMock)
+    @patch("pyvlx.heartbeat.StatusRequest")
+    @patch("pyvlx.heartbeat.GetState")
+    async def test_pulse_skips_opening_devices_in_motion(
+        self,
+        get_state_cls: MagicMock,
+        status_request_cls: MagicMock,
+        sleep_mock: AsyncMock,
+    ) -> None:
+        """Skip status polling for any OpeningDevice currently in motion.
+
+        Polling a node mid-travel makes the KLF200 overrule the active
+        command and can halt the device on some actuators, so the
+        heartbeat must skip any OpeningDevice with is_opening or
+        is_closing set.
+        """
+        moving_gate = Gate(self.pyvlx, node_id=16, name="Gate", serial_number=None)
+        moving_gate.is_closing = True
+        idle_node = MagicMock()
+        idle_node.node_id = 17
+        self.pyvlx.nodes = [moving_gate, idle_node]
+
+        get_state = MagicMock()
+        get_state.do_api_call = AsyncMock()
+        get_state.success = True
+        get_state_cls.return_value = get_state
+
+        status_request = MagicMock()
+        status_request.do_api_call = AsyncMock()
+        status_request_cls.return_value = status_request
+
+        heartbeat = Heartbeat(self.pyvlx, load_all_states=True)
+        await heartbeat.pulse()
+
+        # Only the idle node was polled; the moving gate was skipped.
+        status_request_cls.assert_called_once_with(self.pyvlx, 17)
+        status_request.do_api_call.assert_awaited_once()
+        sleep_mock.assert_awaited_once_with(0.5)

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1820,6 +1820,63 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(gate.position, Position(position_percent=0))
         gate.after_update.assert_awaited_once()
 
+    async def test_stop_mid_travel_does_not_sync_position_via_followup_crsn(self) -> None:
+        """A stop mid-travel must not retroactively sync position to target.
+
+        Reproduces the live KLF200 STOP sequence on IGNORE-position
+        actuators: the original OPEN/CLOSE command is reported as
+        EXECUTION_COMPLETED + COMMAND_OVERRULED (motion cleared, no sync),
+        and the follow-up STOP command finishes as EXECUTION_COMPLETED +
+        COMMAND_COMPLETED_OK. The follow-up's COMMAND_COMPLETED_OK must not
+        cause a position sync, because the motion flags have already been
+        cleared by the OVERRULED handler — the gate is now stopped at an
+        intermediate physical position, not at node.target.
+        """
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        # Pre-move state: device closed, opening command in flight.
+        gate.position = Position(position_percent=100)
+        gate.target = Position(position_percent=0)
+        gate.is_opening = True
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        # First CRSN: original OPEN command is overruled by the STOP.
+        overrule_frame = FrameCommandRunStatusNotification()
+        overrule_frame.index_id = 16
+        overrule_frame.node_parameter = NodeParameter.MP.value
+        overrule_frame.parameter_value = Parameter.UNKNOWN_VALUE
+        overrule_frame.run_status = RunStatus.EXECUTION_COMPLETED
+        overrule_frame.status_reply = StatusReply.COMMAND_OVERRULED
+
+        await self.node_updater.process_frame(overrule_frame)
+
+        self.assertFalse(gate.is_opening)
+        self.assertFalse(gate.is_closing)
+        # Position stays at the stale pre-move cached value.
+        self.assertEqual(gate.position, Position(position_percent=100))
+
+        # Second CRSN: STOP command itself reports clean completion. The
+        # payload value is IGNORE because pyvlx issued the stop via
+        # CurrentPosition, and the gate does not report its concrete stopped
+        # position via this frame.
+        stop_frame = FrameCommandRunStatusNotification()
+        stop_frame.index_id = 16
+        stop_frame.node_parameter = NodeParameter.MP.value
+        stop_frame.parameter_value = Parameter.IGNORE
+        stop_frame.run_status = RunStatus.EXECUTION_COMPLETED
+        stop_frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+
+        await self.node_updater.process_frame(stop_frame)
+
+        # Motion stays cleared and position remains stale: the STOP's
+        # COMMAND_COMPLETED_OK must NOT trigger the sync path, because the
+        # motion flags were already False before this frame arrived.
+        self.assertFalse(gate.is_opening)
+        self.assertFalse(gate.is_closing)
+        self.assertEqual(gate.position, Position(position_percent=100))
+
     async def test_command_run_status_failed_clears_motion_without_position_sync(self) -> None:
         """Clear motion on EXECUTION_FAILED but keep the cached position untouched.
 

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1015,9 +1015,11 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
     async def test_closing_state_cleared_when_cached_position_reaches_closed_extreme_while_executing(self) -> None:
         """A lingering EXECUTING frame after the device reached the closed extreme must clear is_closing.
 
-        Reproduces the garage-door symptom where the gateway emits a final EXECUTING
-        frame with stale remaining_time > 0 after the limit switch trips; without
-        this escape the preserve branch would trap is_closing = True forever.
+        Defensive escape from the preserve branch: when the cached position
+        already matches the target at the closed extreme, an EXECUTING frame
+        with stale remaining_time > 0 must not keep is_closing = True. Without
+        this escape the preserve branch could otherwise trap is_closing forever
+        on such repeated frames.
         """
         device = OpeningDevice(
             pyvlx=self.pyvlx, node_id=81, name="Test garage"
@@ -1723,10 +1725,11 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
     async def test_command_run_status_overruled_still_clears_motion(self) -> None:
         """COMMAND_OVERRULED with EXECUTION_COMPLETED clears motion and syncs position.
 
-        The KLF200 reports COMMAND_OVERRULED when a gate hits its limit switch
-        and the gateway considers the close command 'overruled' by the physical
-        stop. From our point of view the command is over, so motion must clear
-        and the cached position must follow the target.
+        EXECUTION_COMPLETED is treated as the authoritative end-of-command
+        marker regardless of the accompanying status_reply: any reply value
+        (including COMMAND_OVERRULED) ends the active command from our
+        motion-tracking perspective. Motion must clear and the cached
+        position must follow the target.
         """
         gate = Gate(
             pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1754,6 +1754,39 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(gate.position, Position(position_percent=100))
         gate.after_update.assert_awaited_once()
 
+    async def test_command_run_status_completed_tolerates_invalid_parameter_value(self) -> None:
+        """An out-of-range CRSN parameter_value must not crash the handler.
+
+        Defensive guard: unexpected raw values from the gateway are rejected
+        via Parameter.is_valid_int before constructing a Position. The
+        handler then falls back to node.target as the sync source.
+        """
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        gate.position = Position(position_percent=0)
+        gate.target = Position(position_percent=100)
+        gate.is_closing = True
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 16
+        frame.node_parameter = NodeParameter.MP.value
+        # Out of range for Parameter.is_valid_int: above MAX (51200) but
+        # not one of the recognised special markers (UNKNOWN_VALUE,
+        # IGNORE, CURRENT, TARGET, DUAL_SHUTTER_CURTAINS).
+        frame.parameter_value = 60000
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(gate.is_closing)
+        # Fell back to node.target since the payload value was invalid.
+        self.assertEqual(gate.position, Position(position_percent=100))
+        gate.after_update.assert_awaited_once()
+
     async def test_command_run_status_overruled_clears_motion_without_position_sync(self) -> None:
         """COMMAND_OVERRULED clears motion but leaves the cached position untouched.
 

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1754,39 +1754,6 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(gate.position, Position(position_percent=100))
         gate.after_update.assert_awaited_once()
 
-    async def test_command_run_status_completed_tolerates_invalid_parameter_value(self) -> None:
-        """An out-of-range CRSN parameter_value must not crash the handler.
-
-        Defensive guard: unexpected raw values from the gateway are rejected
-        via Parameter.is_valid_int before constructing a Position. The
-        handler then falls back to node.target as the sync source.
-        """
-        gate = Gate(
-            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
-        )
-        gate.position = Position(position_percent=0)
-        gate.target = Position(position_percent=100)
-        gate.is_closing = True
-        gate.after_update = AsyncMock()  # type: ignore[method-assign]
-        self.pyvlx.nodes[16] = gate
-
-        frame = FrameCommandRunStatusNotification()
-        frame.index_id = 16
-        frame.node_parameter = NodeParameter.MP.value
-        # Out of range for Parameter.is_valid_int: above MAX (51200) but
-        # not one of the recognised special markers (UNKNOWN_VALUE,
-        # IGNORE, CURRENT, TARGET, DUAL_SHUTTER_CURTAINS).
-        frame.parameter_value = 60000
-        frame.run_status = RunStatus.EXECUTION_COMPLETED
-        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
-
-        await self.node_updater.process_frame(frame)
-
-        self.assertFalse(gate.is_closing)
-        # Fell back to node.target since the payload value was invalid.
-        self.assertEqual(gate.position, Position(position_percent=100))
-        gate.after_update.assert_awaited_once()
-
     async def test_command_run_status_overruled_clears_motion_without_position_sync(self) -> None:
         """COMMAND_OVERRULED clears motion but leaves the cached position untouched.
 

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1012,6 +1012,69 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertIsNotNone(device.estimated_completion)
         device.after_update.assert_not_awaited()
 
+    async def test_closing_state_cleared_when_cached_position_reaches_closed_extreme_while_executing(self) -> None:
+        """A lingering EXECUTING frame after the device reached the closed extreme must clear is_closing.
+
+        Reproduces the garage-door symptom where the gateway emits a final EXECUTING
+        frame with stale remaining_time > 0 after the limit switch trips; without
+        this escape the preserve branch would trap is_closing = True forever.
+        """
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=81, name="Test garage"
+        )
+        device.position = Position(position_percent=100)
+        device.target = Position(position_percent=100)
+        device.is_closing = True
+        device.state_received_at = datetime.datetime.now()
+        device.estimated_completion = datetime.datetime.now()
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[81] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 81
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=100)
+        frame.remaining_time = 2
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(device.is_closing)
+        self.assertFalse(device.is_opening)
+        self.assertIsNone(device.state_received_at)
+        self.assertIsNone(device.estimated_completion)
+        device.after_update.assert_awaited_once()
+
+    async def test_opening_state_cleared_when_cached_position_reaches_open_extreme_while_executing(self) -> None:
+        """Mirror of the closed-extreme case: lingering EXECUTING frames at the open extreme clear is_opening."""
+        device = OpeningDevice(
+            pyvlx=self.pyvlx, node_id=82, name="Test garage"
+        )
+        device.position = Position(position_percent=0)
+        device.target = Position(position_percent=0)
+        device.is_opening = True
+        device.state_received_at = datetime.datetime.now()
+        device.estimated_completion = datetime.datetime.now()
+        device.last_frame_state = OperatingState.EXECUTING
+        device.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[82] = device
+
+        frame = FrameNodeStatePositionChangedNotification()
+        frame.node_id = 82
+        frame.state = OperatingState.EXECUTING
+        frame.current_position = Position(position=Parameter.UNKNOWN_VALUE)
+        frame.target = Position(position_percent=0)
+        frame.remaining_time = 2
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(device.is_opening)
+        self.assertFalse(device.is_closing)
+        self.assertIsNone(device.state_received_at)
+        self.assertIsNone(device.estimated_completion)
+        device.after_update.assert_awaited_once()
+
     async def test_motion_direction_derived_from_cached_position_when_frame_position_unknown(self) -> None:
         """Frames with IGNORE/UNKNOWN current_position should derive direction from the cached node position."""
         device = OpeningDevice(

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1237,9 +1237,12 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         # EXECUTION_COMPLETED is the reliable end-of-command marker for gates
         # whose position frames stay at IGNORE: motion must clear here, not
-        # wait for a (possibly never-arriving) DONE frame.
+        # wait for a (possibly never-arriving) DONE frame. The cached position
+        # must also follow the target so HA does not briefly report the wrong
+        # cover state from the stale pre-move position.
         self.assertFalse(device.is_opening)
         self.assertFalse(device.is_closing)
+        self.assertEqual(device.position, Position(position_percent=0))
 
         done_frame = FrameNodeStatePositionChangedNotification()
         done_frame.node_id = 80
@@ -1306,9 +1309,12 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         # EXECUTION_COMPLETED is the reliable end-of-command marker for gates
         # whose position frames stay at IGNORE: motion must clear here, not
-        # wait for a (possibly never-arriving) DONE frame.
+        # wait for a (possibly never-arriving) DONE frame. The cached position
+        # must also follow the target so HA does not briefly report the wrong
+        # cover state from the stale pre-move position.
         self.assertFalse(device.is_closing)
         self.assertFalse(device.is_opening)
+        self.assertEqual(device.position, Position(position_percent=100))
 
         done_frame = FrameNodeStatePositionChangedNotification()
         done_frame.node_id = 81
@@ -1681,11 +1687,13 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         mocked_node.after_update.assert_not_awaited()
 
     async def test_command_run_status_completed_clears_opening_device_motion(self) -> None:
-        """EXECUTION_COMPLETED on a moving OpeningDevice must clear is_opening/is_closing.
+        """Clear motion and sync cached position to target on EXECUTION_COMPLETED.
 
         Reproduces the gate symptom where current_position stays IGNORE for the
         whole travel and the command-run-status frame is the only reliable end
-        marker.
+        marker. Without the position sync, HA briefly sees the stale pre-move
+        position (e.g. 0%) and reports the cover at the wrong end before the
+        next heartbeat sweep corrects it.
         """
         gate = Gate(
             pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
@@ -1707,16 +1715,18 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertFalse(gate.is_closing)
         self.assertFalse(gate.is_opening)
+        self.assertEqual(gate.position, Position(position_percent=100))
         self.assertIsNone(gate.state_received_at)
         self.assertIsNone(gate.estimated_completion)
         gate.after_update.assert_awaited_once()
 
     async def test_command_run_status_overruled_still_clears_motion(self) -> None:
-        """COMMAND_OVERRULED with EXECUTION_COMPLETED also clears motion.
+        """COMMAND_OVERRULED with EXECUTION_COMPLETED clears motion and syncs position.
 
         The KLF200 reports COMMAND_OVERRULED when a gate hits its limit switch
         and the gateway considers the close command 'overruled' by the physical
-        stop. From our point of view the command is over, so motion must clear.
+        stop. From our point of view the command is over, so motion must clear
+        and the cached position must follow the target.
         """
         gate = Gate(
             pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
@@ -1736,10 +1746,16 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertFalse(gate.is_closing)
         self.assertFalse(gate.is_opening)
+        self.assertEqual(gate.position, Position(position_percent=100))
         gate.after_update.assert_awaited_once()
 
-    async def test_command_run_status_failed_clears_motion(self) -> None:
-        """EXECUTION_FAILED also ends the command, so motion must clear."""
+    async def test_command_run_status_failed_clears_motion_without_position_sync(self) -> None:
+        """Clear motion on EXECUTION_FAILED but keep the cached position untouched.
+
+        On failure we cannot assume the device reached its target, so the
+        cached position must stay as it was. The next status sweep will
+        provide the real position.
+        """
         garage = GarageDoor(
             pyvlx=self.pyvlx, node_id=17, name="Test garage", serial_number=None
         )
@@ -1758,6 +1774,7 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertFalse(garage.is_closing)
         self.assertFalse(garage.is_opening)
+        self.assertEqual(garage.position, Position(position_percent=0))
         garage.after_update.assert_awaited_once()
 
     async def test_command_run_status_active_keeps_motion(self) -> None:

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1235,7 +1235,10 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         await self.node_updater.process_frame(command_status)
 
-        self.assertTrue(device.is_opening)
+        # EXECUTION_COMPLETED is the reliable end-of-command marker for gates
+        # whose position frames stay at IGNORE: motion must clear here, not
+        # wait for a (possibly never-arriving) DONE frame.
+        self.assertFalse(device.is_opening)
         self.assertFalse(device.is_closing)
 
         done_frame = FrameNodeStatePositionChangedNotification()
@@ -1253,7 +1256,7 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(device.target, Position(position_percent=0))
 
     async def test_gate_closing_live_sequence_keeps_direction_until_done(self) -> None:
-        """Live gate sequence should keep closing through IGNORE frames and stop on DONE."""
+        """Live gate sequence should keep closing through IGNORE frames and stop on COMPLETED/DONE."""
         device = OpeningDevice(pyvlx=self.pyvlx, node_id=81, name="Test gate")
         device.position = Position(position_percent=0)
         device.target = Position(position_percent=0)
@@ -1301,7 +1304,10 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         await self.node_updater.process_frame(command_status)
 
-        self.assertTrue(device.is_closing)
+        # EXECUTION_COMPLETED is the reliable end-of-command marker for gates
+        # whose position frames stay at IGNORE: motion must clear here, not
+        # wait for a (possibly never-arriving) DONE frame.
+        self.assertFalse(device.is_closing)
         self.assertFalse(device.is_opening)
 
         done_frame = FrameNodeStatePositionChangedNotification()
@@ -1673,3 +1679,128 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertEqual(mocked_node.last_frame_status_reply, StatusReply.COMMAND_COMPLETED_OK)
         # Verify after_update was NOT called when nothing changed
         mocked_node.after_update.assert_not_awaited()
+
+    async def test_command_run_status_completed_clears_opening_device_motion(self) -> None:
+        """EXECUTION_COMPLETED on a moving OpeningDevice must clear is_opening/is_closing.
+
+        Reproduces the gate symptom where current_position stays IGNORE for the
+        whole travel and the command-run-status frame is the only reliable end
+        marker.
+        """
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        gate.position = Position(position_percent=0)
+        gate.target = Position(position_percent=100)
+        gate.is_closing = True
+        gate.state_received_at = datetime.datetime.now()
+        gate.estimated_completion = datetime.datetime.now()
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 16
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(gate.is_closing)
+        self.assertFalse(gate.is_opening)
+        self.assertIsNone(gate.state_received_at)
+        self.assertIsNone(gate.estimated_completion)
+        gate.after_update.assert_awaited_once()
+
+    async def test_command_run_status_overruled_still_clears_motion(self) -> None:
+        """COMMAND_OVERRULED with EXECUTION_COMPLETED also clears motion.
+
+        The KLF200 reports COMMAND_OVERRULED when a gate hits its limit switch
+        and the gateway considers the close command 'overruled' by the physical
+        stop. From our point of view the command is over, so motion must clear.
+        """
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        gate.position = Position(position_percent=0)
+        gate.target = Position(position_percent=100)
+        gate.is_closing = True
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 16
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.status_reply = StatusReply.COMMAND_OVERRULED
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(gate.is_closing)
+        self.assertFalse(gate.is_opening)
+        gate.after_update.assert_awaited_once()
+
+    async def test_command_run_status_failed_clears_motion(self) -> None:
+        """EXECUTION_FAILED also ends the command, so motion must clear."""
+        garage = GarageDoor(
+            pyvlx=self.pyvlx, node_id=17, name="Test garage", serial_number=None
+        )
+        garage.position = Position(position_percent=0)
+        garage.target = Position(position_percent=100)
+        garage.is_closing = True
+        garage.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[17] = garage
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 17
+        frame.run_status = RunStatus.EXECUTION_FAILED
+        frame.status_reply = StatusReply.UNKNOWN_STATUS_REPLY
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(garage.is_closing)
+        self.assertFalse(garage.is_opening)
+        garage.after_update.assert_awaited_once()
+
+    async def test_command_run_status_active_keeps_motion(self) -> None:
+        """EXECUTION_ACTIVE indicates the command is still running — motion must stay."""
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        gate.position = Position(position_percent=0)
+        gate.target = Position(position_percent=100)
+        gate.is_closing = True
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 16
+        frame.run_status = RunStatus.EXECUTION_ACTIVE
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertTrue(gate.is_closing)
+        self.assertFalse(gate.is_opening)
+        gate.after_update.assert_awaited_once()
+
+    async def test_command_run_status_completed_idle_device_keeps_idle(self) -> None:
+        """An OpeningDevice without active motion stays idle on EXECUTION_COMPLETED."""
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        gate.position = Position(position_percent=100)
+        gate.is_opening = False
+        gate.is_closing = False
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 16
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(gate.is_closing)
+        self.assertFalse(gate.is_opening)
+        # last_frame_run_status / status_reply still changed → after_update is called.
+        gate.after_update.assert_awaited_once()

--- a/test/node_updater_test.py
+++ b/test/node_updater_test.py
@@ -1229,19 +1229,20 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
             session_id=2,
             status_id=1,
             index_id=80,
-            node_parameter=0,
-            parameter_value=Parameter.UNKNOWN_VALUE,
+            node_parameter=NodeParameter.MP.value,
+            parameter_value=Position(position_percent=0).position,
             run_status=RunStatus.EXECUTION_COMPLETED,
-            status_reply=StatusReply.COMMAND_OVERRULED,
+            status_reply=StatusReply.COMMAND_COMPLETED_OK,
         )
 
         await self.node_updater.process_frame(command_status)
 
-        # EXECUTION_COMPLETED is the reliable end-of-command marker for gates
-        # whose position frames stay at IGNORE: motion must clear here, not
-        # wait for a (possibly never-arriving) DONE frame. The cached position
-        # must also follow the target so HA does not briefly report the wrong
-        # cover state from the stale pre-move position.
+        # COMMAND_COMPLETED_OK is the reliable clean-completion marker for
+        # gates whose position frames stayed at IGNORE: motion must clear
+        # here, not wait for a (possibly never-arriving) DONE frame. The
+        # cached position is synced from the CRSN payload's MP value so HA
+        # does not briefly report the wrong cover state from the stale
+        # pre-move position.
         self.assertFalse(device.is_opening)
         self.assertFalse(device.is_closing)
         self.assertEqual(device.position, Position(position_percent=0))
@@ -1301,19 +1302,20 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
             session_id=2,
             status_id=1,
             index_id=81,
-            node_parameter=0,
-            parameter_value=Parameter.UNKNOWN_VALUE,
+            node_parameter=NodeParameter.MP.value,
+            parameter_value=Position(position_percent=100).position,
             run_status=RunStatus.EXECUTION_COMPLETED,
-            status_reply=StatusReply.COMMAND_OVERRULED,
+            status_reply=StatusReply.COMMAND_COMPLETED_OK,
         )
 
         await self.node_updater.process_frame(command_status)
 
-        # EXECUTION_COMPLETED is the reliable end-of-command marker for gates
-        # whose position frames stay at IGNORE: motion must clear here, not
-        # wait for a (possibly never-arriving) DONE frame. The cached position
-        # must also follow the target so HA does not briefly report the wrong
-        # cover state from the stale pre-move position.
+        # COMMAND_COMPLETED_OK is the reliable clean-completion marker for
+        # gates whose position frames stayed at IGNORE: motion must clear
+        # here, not wait for a (possibly never-arriving) DONE frame. The
+        # cached position is synced from the CRSN payload's MP value so HA
+        # does not briefly report the wrong cover state from the stale
+        # pre-move position.
         self.assertFalse(device.is_closing)
         self.assertFalse(device.is_opening)
         self.assertEqual(device.position, Position(position_percent=100))
@@ -1688,14 +1690,13 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         # Verify after_update was NOT called when nothing changed
         mocked_node.after_update.assert_not_awaited()
 
-    async def test_command_run_status_completed_clears_opening_device_motion(self) -> None:
-        """Clear motion and sync cached position to target on EXECUTION_COMPLETED.
+    async def test_command_run_status_completed_clears_motion_and_syncs_position_from_payload(self) -> None:
+        """Clear motion and sync position from the CRSN payload's MP value.
 
         Reproduces the gate symptom where current_position stays IGNORE for the
         whole travel and the command-run-status frame is the only reliable end
-        marker. Without the position sync, HA briefly sees the stale pre-move
-        position (e.g. 0%) and reports the cover at the wrong end before the
-        next heartbeat sweep corrects it.
+        marker. The CRSN payload carries the final main-parameter value, which
+        is the most up-to-date source for the synced position.
         """
         gate = Gate(
             pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
@@ -1710,6 +1711,8 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         frame = FrameCommandRunStatusNotification()
         frame.index_id = 16
+        frame.node_parameter = NodeParameter.MP.value
+        frame.parameter_value = Position(position_percent=100).position
         frame.run_status = RunStatus.EXECUTION_COMPLETED
         frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
 
@@ -1722,14 +1725,12 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
         self.assertIsNone(gate.estimated_completion)
         gate.after_update.assert_awaited_once()
 
-    async def test_command_run_status_overruled_still_clears_motion(self) -> None:
-        """COMMAND_OVERRULED with EXECUTION_COMPLETED clears motion and syncs position.
+    async def test_command_run_status_completed_falls_back_to_target_when_payload_unusable(self) -> None:
+        """Sync from node.target when the CRSN payload does not carry a concrete MP value.
 
-        EXECUTION_COMPLETED is treated as the authoritative end-of-command
-        marker regardless of the accompanying status_reply: any reply value
-        (including COMMAND_OVERRULED) ends the active command from our
-        motion-tracking perspective. Motion must clear and the cached
-        position must follow the target.
+        Some gateways send the COMPLETED notification with parameter_value =
+        UNKNOWN; in that case the cached node.target is the next-best source
+        for the post-move position.
         """
         gate = Gate(
             pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
@@ -1742,6 +1743,38 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         frame = FrameCommandRunStatusNotification()
         frame.index_id = 16
+        frame.node_parameter = NodeParameter.MP.value
+        frame.parameter_value = Parameter.UNKNOWN_VALUE
+        frame.run_status = RunStatus.EXECUTION_COMPLETED
+        frame.status_reply = StatusReply.COMMAND_COMPLETED_OK
+
+        await self.node_updater.process_frame(frame)
+
+        self.assertFalse(gate.is_closing)
+        self.assertEqual(gate.position, Position(position_percent=100))
+        gate.after_update.assert_awaited_once()
+
+    async def test_command_run_status_overruled_clears_motion_without_position_sync(self) -> None:
+        """COMMAND_OVERRULED clears motion but leaves the cached position untouched.
+
+        COMMAND_OVERRULED means the active run was pre-empted (e.g. by a new
+        command or a stop), so the device did not necessarily reach the
+        target. We must therefore only clear the motion flags and leave the
+        position for whatever follow-up state frame establishes.
+        """
+        gate = Gate(
+            pyvlx=self.pyvlx, node_id=16, name="Test gate", serial_number=None
+        )
+        gate.position = Position(position_percent=0)
+        gate.target = Position(position_percent=100)
+        gate.is_closing = True
+        gate.after_update = AsyncMock()  # type: ignore[method-assign]
+        self.pyvlx.nodes[16] = gate
+
+        frame = FrameCommandRunStatusNotification()
+        frame.index_id = 16
+        frame.node_parameter = NodeParameter.MP.value
+        frame.parameter_value = Position(position_percent=100).position
         frame.run_status = RunStatus.EXECUTION_COMPLETED
         frame.status_reply = StatusReply.COMMAND_OVERRULED
 
@@ -1749,7 +1782,9 @@ class TestNodeUpdater(IsolatedAsyncioTestCase):
 
         self.assertFalse(gate.is_closing)
         self.assertFalse(gate.is_opening)
-        self.assertEqual(gate.position, Position(position_percent=100))
+        # Position stays at the pre-CRSN cached value because OVERRULED does
+        # not guarantee that the device reached node.target.
+        self.assertEqual(gate.position, Position(position_percent=0))
         gate.after_update.assert_awaited_once()
 
     async def test_command_run_status_failed_clears_motion_without_position_sync(self) -> None:


### PR DESCRIPTION
## Background

After PR #665 (preserve movement state during executing frames with unavailable
positions), `is_opening` / `is_closing` can get stuck on `True` for actuators
whose position frames stay at `IGNORE` for most of their travel — typically
gates and some garage doors. The session ends only via
`FrameCommandRunStatusNotification` (CRSN), which the NodeUpdater previously
did not consider as a motion terminator. Downstream consumers (Home Assistant
cover entities) then remained in `opening`/`closing` until the next polled
status sweep, sometimes for a full heartbeat period.

A second, independent issue: the heartbeat sweep calls `StatusRequest` on
every node — including nodes currently executing a command. This can make the
gateway report the active command as completed prematurely (occasionally with
`status_reply = COMMAND_OVERRULED`) and on some actuators it can interrupt the
motion. Downstream consumers cannot tell that completion apart from a genuine
end-of-travel completion.

## What this PR changes

Four small, complementary fixes:

1. **`node_updater._update_opening_device_status`** — escape from the preserve
   branch when the cached position has reached the open/closed extreme matching
   the target. Defensive cleanup so a repeated EXECUTING frame at the extreme
   cannot trap motion state.
2. **`node_updater._process_command_run_status_notification`** — treat
   `run_status` ∈ {`EXECUTION_COMPLETED`, `EXECUTION_FAILED`} as the
   authoritative end-of-command marker for OpeningDevices. Clear
   `is_opening`/`is_closing` and reset `state_received_at` /
   `estimated_completion`.
3. **Position sync — only on a clean completion**: when `run_status =
   EXECUTION_COMPLETED` and `status_reply = COMMAND_COMPLETED_OK`,
   additionally sync the cached position so consumers don't briefly see a
   stale pre-move value between motion-clear and the next house-monitoring
   frame. The sync source is the CRSN payload's main-parameter value
   (`frame.parameter_value` when `node_parameter == NodeParameter.MP` and
   the raw value passes `Parameter.is_valid_int` + is concrete), with
   `node.target` as fallback. Other `status_reply` values (e.g.
   `COMMAND_OVERRULED`) and `EXECUTION_FAILED` leave the position untouched,
   because the run was pre-empted or failed before reaching the target.
4. **`heartbeat.pulse`** — skip `StatusRequest` for any `OpeningDevice` whose
   `is_opening` or `is_closing` is set. House Monitoring delivers in-flight
   position updates anyway, so the sweep adds no value during motion and only
   risks the side effects above.

Tests:
- New tests covering motion-clear + position sync paths for COMPLETED_OK
  (from CRSN payload), COMPLETED_OK with non-concrete payload (fallback to
  `node.target`), COMPLETED_OK with an out-of-range payload (defensive
  fallback), OVERRULED (motion clears, position stays), and FAILED (motion
  clears, position stays).
- New test that the heartbeat skips moving OpeningDevices.
- Existing live-sequence tests
  (`test_gate_opening_live_sequence_keeps_direction_until_done` and the
  closing counterpart) updated to reflect the new contract: motion is
  cleared at CRSN COMPLETED_OK with a concrete MP payload (matching what
  live traces show real gateways send at clean session end), and the
  subsequent `state=DONE` frame confirms the final state.

`make ci` is green (498 tests; mypy / pylint / pydocstyle / flake8 / isort
clean).

## Trace-based context

To validate the fix in the wild, I ran a single-pass test against my live
gateway, cycling every OpeningDevice through `open → close → open` (or
`open → close` for gate/garage). The traces and the throw-away driver script
are local artifacts and are **not** part of this PR; the conclusions are
summarised below.

What the traces show about the gateway's behaviour:

- **Initial state on connect is unreliable.** After `load_nodes()` many
  OpeningDevices first show up with `position=UNKNOWN target=UNKNOWN`.
  Concrete values arrive later via House-Monitoring frames. Consumers
  must not act on the initial snapshot as if it were authoritative.

- **`state = OperatingState.UNKNOWN` does NOT imply unusable position.**
  The gateway emits a steady stream of passive frames such as
  `state=OperatingState.UNKNOWN current=0 % target=0 %` for idle nodes.
  Position is typically concrete and correct. State and position have
  to be evaluated independently.

- **Gates and garage doors differ structurally.** The garage door emits
  concrete intermediate positions during travel (17 %, 3 %, 0 %). The
  gate emits `current_position = IGNORE` for almost the entire travel;
  only `target` stays concrete. The cached-position / cached-target
  fallback from #665 is the only way to derive direction during that
  IGNORE phase.

- **`remaining_time` is not a reliable countdown.** On the gate
  `remaining=3` stayed pinned at the same value across many frames; on
  the garage door several `remaining=0` frames arrived before the
  actual session-end. Using `remaining_time` only as an "is in motion"
  hint, not as a timer, is the right call.

- **CRSN is the authoritative end-of-command marker.**
  `FrameCommandRunStatusNotification (run_status=EXECUTION_COMPLETED,
  status_reply=COMMAND_COMPLETED_OK)` arrived reliably at clean session
  end, either just before or together with the final `state=DONE`
  position frame, and carried the final main-parameter value in its
  payload. For gate-style devices that stay at `IGNORE` until the end
  this is the only robust completion signal — which is why fix (2)
  ties motion-clear into the CRSN path, and fix (3) prefers the CRSN
  payload over the cached `node.target`.

- **The KLF200 is sensitive to long/aggressive polling.** During a
  long marathon trace the first ~12 devices completed cleanly;
  afterwards the gateway dropped the TCP socket and refused new
  connections (`[Errno 61] Connect call failed`). This PR does not
  claim to fix that, but it does reduce avoidable `StatusRequest`
  pressure against devices that are already busy.

### Caveats on the trace evidence

- The trace driver uses `PyVLX(..., heartbeat_interval=3600)`, so the
  successful gate cycles (≈ 39 s / 47 s) ran with the regular 30 s
  heartbeat effectively suppressed. The traces therefore confirm the
  *conditions* under which mid-motion polling is risky (long travel,
  long IGNORE phase, CRSN as only end marker), but they are not a
  direct A/B demonstration of fix (4).
- The garage door CRSN test path is visible in the traces: at
  `EXECUTION_COMPLETED` the cached position and motion flags update in
  the same tick, and the following `state=DONE` frame confirms the
  same final state.

## Why a 0.2.35 release matters

The currently released `pyvlx 0.2.33` does not have this regression
yet — it was introduced together with PR #665 ("Preserve movement
state during executing frames with unavailable positions") and is in
`pyvlx 0.2.34`. Home Assistant's stable `velux` integration still
pins `pyvlx == 0.2.33`; the Home Assistant `dev` branch already moved
its pin to `pyvlx == 0.2.34`. The next Home Assistant stable release
cut from `dev` will therefore ship the regression to the broader user
base unless a fixed `pyvlx` release replaces the pin first.

User-visible symptoms on IGNORE-position actuators (gates, certain
garage doors) with `pyvlx 0.2.34`:

- Cover entities stay in `opening` / `closing` after the actuator has
  physically reached its end position, until the next heartbeat sweep
  (~30 s) or a fresh user command resets the state. Automations keyed
  on `is_closed` therefore see a wrong terminal state for that
  window.
- Heartbeat-driven `StatusRequest` calls during an active motion can
  prematurely complete the running command — on some actuators the
  gateway additionally interrupts the motion mid-travel.

The device remains controllable in all these cases (a new command
resets the state via the usual paths), but the displayed state and
any state-driven automation logic are wrong in the meantime. Cutting
a `0.2.35` with this fix before Home Assistant freezes its next
release would avoid the regression hitting users at all.

## Test plan

- [x] `make ci` green on this branch.
- [x] Live-tested on a private installation: gate (long travel, IGNORE),
      garage door (mixed concrete + IGNORE), Velux roof window
      (concrete throughout), and several roller shutters. All went
      through `opening → open` / `closing → closed` cleanly without
      sticking or briefly flipping to the wrong end-state.
- [x] Live-cycled every OpeningDevice via the trace driver in one pass
      (see traces above) — same outcome.