### PR TITLE
Fix set limitation

### DIFF
--- a/src/pyvlx/api/set_limitation.py
+++ b/src/pyvlx/api/set_limitation.py
@@ -1,12 +1,13 @@
 """Module for setting limitation value."""
 from typing import TYPE_CHECKING
 
-from pyvlx.const import LimitationTime, Originator
+from ..const import LimitationTime
 
 from ..parameter import IgnorePosition, Position
 from .api_event import ApiEvent
 from .frames import (
-    FrameBase, FrameSetLimitationConfirmation, FrameSetLimitationRequest,
+    FrameBase, FrameGetLimitationStatusNotification, FrameSessionFinishedNotification,
+    FrameSetLimitationConfirmation, FrameSetLimitationRequest,
     SetLimitationRequestStatus)
 from .session_id import get_new_session_id
 
@@ -27,18 +28,29 @@ class SetLimitation(ApiEvent):
         self.limitation_value_min = limitation_value_min
         self.limitation_value_max = limitation_value_max
         self.success = False
-        self.notification_frame: FrameSetLimitationConfirmation | None = None
         self.session_id: int | None = None
-        self.originator: Originator | None = None
         self.limitation_time = limitation_time
 
     async def handle_frame(self, frame: FrameBase) -> bool:
         """Handle incoming API frame, return True if this was the expected frame."""
-        if isinstance(frame, FrameSetLimitationConfirmation):
+        if isinstance(frame, FrameSetLimitationConfirmation) and frame.session_id == self.session_id:
             if frame.status == SetLimitationRequestStatus.REJECTED:
+                # The request was rejected, so success is False. There is also no point in waiting
+                # for a completion notification, since the command was not accepted, so we can consider
+                # the API call complete at this point and return True to stop waiting for further frames.
                 self.success = False
-            else:
-                self.success = True
+                return True
+        if isinstance(frame, FrameGetLimitationStatusNotification) and frame.session_id == self.session_id:
+            # received a notification frame with the new limitation values, so we can consider
+            # the API call successful and complete at this point. (see Spec section 10.5.4)
+            self.success = True
+            return True
+        if isinstance(frame, FrameSessionFinishedNotification) and frame.session_id == self.session_id:
+            # The session finished without us having seen a notification frame with the new limitation values, so
+            # we consider the API call complete at this point.
+            # Success remains False, since we never received the notification frame with the new values. 
+            # We've most likely seen a FrameCommandRunStatusNotification in between the confirmation and
+            # the session finished notification, which indicates that the command was not accepted by the device.
             return True
         return False
 

--- a/src/pyvlx/api/set_limitation.py
+++ b/src/pyvlx/api/set_limitation.py
@@ -2,13 +2,12 @@
 from typing import TYPE_CHECKING
 
 from ..const import LimitationTime
-
 from ..parameter import IgnorePosition, Position
 from .api_event import ApiEvent
 from .frames import (
-    FrameBase, FrameGetLimitationStatusNotification, FrameSessionFinishedNotification,
-    FrameSetLimitationConfirmation, FrameSetLimitationRequest,
-    SetLimitationRequestStatus)
+    FrameBase, FrameGetLimitationStatusNotification,
+    FrameSessionFinishedNotification, FrameSetLimitationConfirmation,
+    FrameSetLimitationRequest, SetLimitationRequestStatus)
 from .session_id import get_new_session_id
 
 if TYPE_CHECKING:
@@ -48,7 +47,7 @@ class SetLimitation(ApiEvent):
         if isinstance(frame, FrameSessionFinishedNotification) and frame.session_id == self.session_id:
             # The session finished without us having seen a notification frame with the new limitation values, so
             # we consider the API call complete at this point.
-            # Success remains False, since we never received the notification frame with the new values. 
+            # Success remains False, since we never received the notification frame with the new values.
             # We've most likely seen a FrameCommandRunStatusNotification in between the confirmation and
             # the session finished notification, which indicates that the command was not accepted by the device.
             return True

--- a/src/pyvlx/api/set_limitation.py
+++ b/src/pyvlx/api/set_limitation.py
@@ -32,19 +32,21 @@ class SetLimitation(ApiEvent):
 
     async def handle_frame(self, frame: FrameBase) -> bool:
         """Handle incoming API frame, return True if this was the expected frame."""
-        if isinstance(frame, FrameSetLimitationConfirmation) and frame.session_id == self.session_id:
-            if frame.status == SetLimitationRequestStatus.REJECTED:
-                # The request was rejected, so success is False. There is also no point in waiting
-                # for a completion notification, since the command was not accepted, so we can consider
-                # the API call complete at this point and return True to stop waiting for further frames.
-                self.success = False
-                return True
-        if isinstance(frame, FrameGetLimitationStatusNotification) and frame.session_id == self.session_id:
+        if hasattr(frame, "session_id") and frame.session_id != self.session_id:
+            # This frame has a session id, but it doesn't match the one of this API call, so ignore it.
+            return False
+        if isinstance(frame, FrameSetLimitationConfirmation) and frame.status == SetLimitationRequestStatus.REJECTED:
+            # The request was rejected, so success is False. There is also no point in waiting
+            # for a completion notification, since the command was not accepted, so we can consider
+            # the API call complete at this point and return True to stop waiting for further frames.
+            self.success = False
+            return True
+        if isinstance(frame, FrameGetLimitationStatusNotification):
             # received a notification frame with the new limitation values, so we can consider
             # the API call successful and complete at this point. (see Spec section 10.5.4)
             self.success = True
             return True
-        if isinstance(frame, FrameSessionFinishedNotification) and frame.session_id == self.session_id:
+        if isinstance(frame, FrameSessionFinishedNotification):
             # The session finished without us having seen a notification frame with the new limitation values, so
             # we consider the API call complete at this point.
             # Success remains False, since we never received the notification frame with the new values.

--- a/src/pyvlx/opening_device.py
+++ b/src/pyvlx/opening_device.py
@@ -214,7 +214,7 @@ class OpeningDevice(Node):
         )
         await command_set_limitation.do_api_call()
         if not command_set_limitation.success:
-            raise PyVLXException("Unable to set limitations")
+            raise PyVLXException(f"Unable to set limitations for node_id {self.node_id}")
         self.limitation_min = position_min
         self.limitation_max = position_max
         await self.after_update()
@@ -228,7 +228,7 @@ class OpeningDevice(Node):
         )
         await command_set_limitation.do_api_call()
         if not command_set_limitation.success:
-            raise PyVLXException("Unable to clear limitations")
+            raise PyVLXException(f"Unable to clear limitations for node_id {self.node_id}")
         self.limitation_min = IgnorePosition()
         self.limitation_max = IgnorePosition()
         await self.after_update()
@@ -242,7 +242,7 @@ class OpeningDevice(Node):
         )
         await command_get_limitation.do_api_call()
         if not command_get_limitation.success:
-            raise PyVLXException("Unable to get minimum limitation")
+            raise PyVLXException(f"Unable to get minimum limitation for node_id {self.node_id}")
 
         self.limitation_min = Position(position_percent=command_get_limitation.min_value)
 
@@ -257,7 +257,7 @@ class OpeningDevice(Node):
         )
         await command_get_limitation.do_api_call()
         if not command_get_limitation.success:
-            raise PyVLXException("Unable to get maximum limitation")
+            raise PyVLXException(f"Unable to get maximum limitation for node_id {self.node_id}")
 
         self.limitation_max = Position(position_percent=command_get_limitation.max_value)
 

--- a/test/set_limitation_test.py
+++ b/test/set_limitation_test.py
@@ -3,8 +3,10 @@ import unittest
 from unittest.mock import MagicMock
 
 from pyvlx import PyVLX
-from pyvlx.api.frames.frame_command_send import FrameSessionFinishedNotification
-from pyvlx.api.frames.frame_get_limitation import FrameGetLimitationStatusNotification
+from pyvlx.api.frames.frame_command_send import (
+    FrameSessionFinishedNotification)
+from pyvlx.api.frames.frame_get_limitation import (
+    FrameGetLimitationStatusNotification)
 from pyvlx.api.frames.frame_set_limitation import (
     FrameSetLimitationConfirmation, FrameSetLimitationRequest,
     SetLimitationRequestStatus)

--- a/test/set_limitation_test.py
+++ b/test/set_limitation_test.py
@@ -3,6 +3,8 @@ import unittest
 from unittest.mock import MagicMock
 
 from pyvlx import PyVLX
+from pyvlx.api.frames.frame_command_send import FrameSessionFinishedNotification
+from pyvlx.api.frames.frame_get_limitation import FrameGetLimitationStatusNotification
 from pyvlx.api.frames.frame_set_limitation import (
     FrameSetLimitationConfirmation, FrameSetLimitationRequest,
     SetLimitationRequestStatus)
@@ -20,20 +22,78 @@ class TestSetLimitation(unittest.IsolatedAsyncioTestCase):
 
     async def test_handle_frames_accepted(self) -> None:
         """Test handle frame."""
+        # command accepted does not mean it was successful, neither was the API call completed.
         limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
 
         frame = FrameSetLimitationConfirmation()
+        frame.session_id = 123
         frame.status = SetLimitationRequestStatus.ACCEPTED
+        self.assertFalse(await limit.handle_frame(frame))
+        self.assertFalse(limit.success)
+
+    async def test_handle_request_status_frame_rejected(self) -> None:
+        """Test handle frame."""
+        limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
+
+        frame = FrameSetLimitationConfirmation()
+        frame.session_id = 123
+        frame.status = SetLimitationRequestStatus.REJECTED
+        self.assertTrue(await limit.handle_frame(frame))
+        self.assertFalse(limit.success)
+
+    async def test_handle_request_status_frame_rejected_wrong_session_id(self) -> None:
+        """Test handle frame."""
+        # frames with wrong session id should be ignored, so the API call is not completed and success remains False.
+        limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
+
+        frame = FrameSetLimitationConfirmation()
+        frame.session_id = 456
+        frame.status = SetLimitationRequestStatus.REJECTED
+
+        self.assertFalse(await limit.handle_frame(frame))
+        self.assertFalse(limit.success)
+
+    async def test_handle_limits_received_frame(self) -> None:
+        """Test handle frame."""
+        limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
+
+        frame = FrameGetLimitationStatusNotification()
+        frame.session_id = 123
         self.assertTrue(await limit.handle_frame(frame))
         self.assertTrue(limit.success)
 
-    async def test_handle_frame_rejected(self) -> None:
+    async def test_handle_limits_received_frame_wrong_session_id(self) -> None:
+        """Test handle frame."""
+        # frames with wrong session id should be ignored, so the API call is not completed and success remains False.
+        limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
+
+        frame = FrameGetLimitationStatusNotification()
+        frame.session_id = 456
+        self.assertFalse(await limit.handle_frame(frame))
+        self.assertFalse(limit.success)
+
+    async def test_handle_session_finished_frame(self) -> None:
         """Test handle frame."""
         limit = SetLimitation(self.pyvlx, 1)
 
-        frame = FrameSetLimitationConfirmation()
-        frame.status = SetLimitationRequestStatus.REJECTED
+        frame = FrameSessionFinishedNotification()
         self.assertTrue(await limit.handle_frame(frame))
+        self.assertFalse(limit.success)
+
+    async def test_handle_session_finished_frame_wrong_session_id(self) -> None:
+        """Test handle frame."""
+        # frames with wrong session id should be ignored, so the API call is not completed and success remains False.
+        limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
+
+        frame = FrameSessionFinishedNotification()
+        frame.session_id = 456
+        self.assertFalse(await limit.handle_frame(frame))
         self.assertFalse(limit.success)
 
     def test_request_frame(self) -> None:

--- a/test/set_limitation_test.py
+++ b/test/set_limitation_test.py
@@ -82,8 +82,10 @@ class TestSetLimitation(unittest.IsolatedAsyncioTestCase):
     async def test_handle_session_finished_frame(self) -> None:
         """Test handle frame."""
         limit = SetLimitation(self.pyvlx, 1)
+        limit.session_id = 123
 
         frame = FrameSessionFinishedNotification()
+        frame.session_id = 123
         self.assertTrue(await limit.handle_frame(frame))
         self.assertFalse(limit.success)
 


### PR DESCRIPTION
While testing the feature introduced in #327 I found that checking for the gateway accepting the SetLimitation request is not enough for the request to be considered successful. Some devices can still fail to accept the new limits, for example all the windows I tested do not accept a limit on how far they can be closed. Failure is then signalled with a `FrameCommandRunStatusNotification` and status code `EXECUTION_FAILED`. This is actually documented in the spec, we need to wait for a `FrameGetLimitationStatusNotification` with the new limits as a success criterion. 

So this is what this PR implements, it waits for the gateway actually sending the limits frame before returning `success` as the API call result. 

In addition it fixes a problem with the code not testing that the `FrameSetLimitationConfirmation` has the correct session id, which could potentially confirm/reject the wrong request. 