### PR TITLE
Fix broken NodeVariation Enum

### DIFF
--- a/src/pyvlx/const.py
+++ b/src/pyvlx/const.py
@@ -350,7 +350,7 @@ class NodeVariation(Enum):
     TOPHUNG = 1
     KIP = 2
     FLAT_ROOT = 3
-    SKY_LIGHT = 3
+    SKY_LIGHT = 4
 
 
 class DHCPParameter(Enum):


### PR DESCRIPTION
Looking at git blame the typo in this enum was there from the very beginning, so it seems nobody has ever used this lib with a SKY_LIGHT type window. 