### PR TITLE
Provide node update method to get latest status from gateway

### DIFF
--- a/src/pyvlx/heartbeat.py
+++ b/src/pyvlx/heartbeat.py
@@ -4,7 +4,6 @@ from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from .api import GetState
-from .api.status_request import StatusRequest
 from .exception import PyVLXException
 from .log import PYVLXLOG
 from .opening_device import Blind, DualRollerShutter, OpeningDevice
@@ -100,7 +99,6 @@ class Heartbeat:
                 )
                 continue
             if isinstance(node, (Blind, DualRollerShutter)) or self.load_all_states:
-                status_request = StatusRequest(self.pyvlx, node.node_id)
-                await status_request.do_api_call()
+                await node.update_status()
                 # give user requests a chance
                 await asyncio.sleep(0.5)

--- a/src/pyvlx/node.py
+++ b/src/pyvlx/node.py
@@ -7,6 +7,8 @@ and roller shutters.
 """
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List
 
+from pyvlx.api.status_request import StatusRequest
+
 from .api import SetNodeName, WinkSend
 from .const import OperatingState, RunStatus, StatusReply, WinkTime
 from .exception import PyVLXException
@@ -86,6 +88,11 @@ class Node:
         if not set_node_name.success:
             raise PyVLXException("Unable to rename node")
         self.name = name
+
+    async def update_status(self) -> None:
+        """Update node status from gateway."""
+        status_request = StatusRequest(self.pyvlx, self.node_id)
+        await status_request.do_api_call()
 
     async def wink(self, wink_time: WinkTime = WinkTime.BY_MANUFACTURER, wait_for_completion: bool = True) -> None:
         """Identify node by making it wink."""

--- a/test/heartbeat_test.py
+++ b/test/heartbeat_test.py
@@ -2,7 +2,7 @@
 import asyncio
 from collections.abc import Coroutine
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyvlx import PyVLX
 from pyvlx.exception import PyVLXException
@@ -119,16 +119,16 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
             await heartbeat.pulse()
 
     @patch("pyvlx.heartbeat.asyncio.sleep", new_callable=AsyncMock)
-    @patch("pyvlx.heartbeat.StatusRequest")
     @patch("pyvlx.heartbeat.GetState")
     async def test_pulse_loads_only_blind_nodes_when_configured(
         self,
         get_state_cls: MagicMock,
-        status_request_cls: MagicMock,
         sleep_mock: AsyncMock,
     ) -> None:
         """Test pulse() requests status only for blind-type nodes when load_all_states is disabled."""
-        blind = Blind(self.pyvlx, node_id=1, name="Blind", serial_number=None)
+        blind = MagicMock(spec=Blind)
+        blind.is_opening = False
+        blind.is_closing = False
         non_blind = MagicMock()
         non_blind.node_id = 2
         self.pyvlx.nodes = [blind, non_blind]
@@ -138,31 +138,27 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
         get_state.success = True
         get_state_cls.return_value = get_state
 
-        status_request = MagicMock()
-        status_request.do_api_call = AsyncMock()
-        status_request_cls.return_value = status_request
-
         heartbeat = Heartbeat(self.pyvlx, load_all_states=False)
         await heartbeat.pulse()
 
-        status_request_cls.assert_called_once_with(self.pyvlx, 1)
-        status_request.do_api_call.assert_awaited_once()
+        blind.update_status.assert_awaited_once()
+        non_blind.update_status.assert_not_called()
         sleep_mock.assert_awaited_once_with(0.5)
 
     @patch("pyvlx.heartbeat.asyncio.sleep", new_callable=AsyncMock)
-    @patch("pyvlx.heartbeat.StatusRequest")
     @patch("pyvlx.heartbeat.GetState")
     async def test_pulse_loads_all_nodes_when_enabled(
         self,
         get_state_cls: MagicMock,
-        status_request_cls: MagicMock,
         sleep_mock: AsyncMock,
     ) -> None:
         """Test pulse() requests status for every node when load_all_states is enabled."""
-        node_1 = MagicMock()
-        node_1.node_id = 11
-        node_2 = MagicMock()
-        node_2.node_id = 12
+        node_1 = AsyncMock()
+        node_1.is_closing = False
+        node_1.is_opening = False
+        node_2 = AsyncMock()
+        node_2.is_closing = False
+        node_2.is_opening = False
         self.pyvlx.nodes = [node_1, node_2]
 
         get_state = MagicMock()
@@ -170,30 +166,18 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
         get_state.success = True
         get_state_cls.return_value = get_state
 
-        status_request_1 = MagicMock()
-        status_request_1.do_api_call = AsyncMock()
-        status_request_2 = MagicMock()
-        status_request_2.do_api_call = AsyncMock()
-        status_request_cls.side_effect = [status_request_1, status_request_2]
-
         heartbeat = Heartbeat(self.pyvlx, load_all_states=True)
         await heartbeat.pulse()
 
-        self.assertEqual(
-            status_request_cls.call_args_list,
-            [call(self.pyvlx, 11), call(self.pyvlx, 12)],
-        )
-        status_request_1.do_api_call.assert_awaited_once()
-        status_request_2.do_api_call.assert_awaited_once()
+        assert node_1.update_status.await_count == 1
+        assert node_2.update_status.await_count == 1
         self.assertEqual(sleep_mock.await_count, 2)
 
     @patch("pyvlx.heartbeat.asyncio.sleep", new_callable=AsyncMock)
-    @patch("pyvlx.heartbeat.StatusRequest")
     @patch("pyvlx.heartbeat.GetState")
     async def test_pulse_skips_opening_devices_in_motion(
         self,
         get_state_cls: MagicMock,
-        status_request_cls: MagicMock,
         sleep_mock: AsyncMock,
     ) -> None:
         """Skip status polling for any OpeningDevice currently in motion.
@@ -203,10 +187,11 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
         interrupt the motion. The heartbeat must therefore skip any
         OpeningDevice with is_opening or is_closing set.
         """
-        moving_gate = Gate(self.pyvlx, node_id=16, name="Gate", serial_number=None)
+        moving_gate = MagicMock(spec=Gate)
         moving_gate.is_closing = True
-        idle_node = MagicMock()
-        idle_node.node_id = 17
+        moving_gate.is_opening = False
+        moving_gate.name = "Moving Gate"
+        idle_node = AsyncMock()
         self.pyvlx.nodes = [moving_gate, idle_node]
 
         get_state = MagicMock()
@@ -214,14 +199,11 @@ class TestHeartbeat(IsolatedAsyncioTestCase):
         get_state.success = True
         get_state_cls.return_value = get_state
 
-        status_request = MagicMock()
-        status_request.do_api_call = AsyncMock()
-        status_request_cls.return_value = status_request
-
         heartbeat = Heartbeat(self.pyvlx, load_all_states=True)
         await heartbeat.pulse()
 
         # Only the idle node was polled; the moving gate was skipped.
-        status_request_cls.assert_called_once_with(self.pyvlx, 17)
-        status_request.do_api_call.assert_awaited_once()
+        idle_node.update_status.assert_awaited_once()
+        moving_gate.update_status.assert_not_called()
+
         sleep_mock.assert_awaited_once_with(0.5)


### PR DESCRIPTION
This PR moves the StatusRequest API call from the heartbeat into a method of the node class (and adapts the tests to this change). This makes it cleaner to update the status of a node outside of the heartbeat. 